### PR TITLE
<cache>.dump() for debugging/observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ Usage:
     cache.set("key", "value")
     cache.get("key") // "value"
 
+    cache.reset()    // empty the cache
+
 RTFS for more info.

--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -49,6 +49,12 @@ function LRUCache (maxLength) {
     length = 0
   }
 
+  // Provided for debugging/dev purposes only. No promises whatsoever that
+  // this API stays stable.
+  this.dump = function () {
+    return cache
+  }
+
   this.set = function (key, value) {
     if (hOP(cache, key)) {
       this.get(key)

--- a/test/basic.js
+++ b/test/basic.js
@@ -60,7 +60,7 @@ test('maxLength', function (t) {
   for (var i = 98; i < 100; i ++) {
     t.equal(cache.get(i), i)
   }
-  
+
   // now remove the maxLength restriction, and try again.
   cache.maxLength = "hello"
   for (var i = 0; i < 100; i ++) cache.set(i, i)
@@ -89,5 +89,29 @@ test('reset', function (t) {
   t.equal(cache.maxLength, 10)
   t.equal(cache.get("a"), undefined)
   t.equal(cache.get("b"), undefined)
+  t.end()
+})
+
+// Note: `<cache>.dump()` is a debugging tool only. No guarantees are made
+// about the format/layout of the response.
+test('dump', function (t) {
+  var cache = new LRU(10)
+  var d = cache.dump();
+  t.equal(Object.keys(d).length, 0, "nothing in dump for empty cache")
+  cache.set("a", "A")
+  var d = cache.dump()  // { a: { key: 'a', value: 'A', lu: 0 } }
+  t.ok(d.a)
+  t.equal(d.a.key, 'a')
+  t.equal(d.a.value, 'A')
+  t.equal(d.a.lu, 0)
+
+  cache.set("b", "B")
+  cache.get("b")
+  d = cache.dump()
+  t.ok(d.b)
+  t.equal(d.b.key, 'b')
+  t.equal(d.b.value, 'B')
+  t.equal(d.b.lu, 2)
+
   t.end()
 })


### PR DESCRIPTION
No guarantees out response structure.

Isaac,
I want to use this in Amon to help with debugging caching problems: i.e. use a dump of the current state of the caches to see if expected cache invalidation is being done.
