### PR TITLE
small performance improvement to lruWalk

### DIFF
--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -172,7 +172,8 @@ function LRUCache (options) {
 
   function lruWalk () {
     // lru has been deleted, hop up to the next hit.
-    lru = Object.keys(lruList)[0]
+		for( var key in lruList )
+			return key;
   }
 
   function trim () {


### PR DESCRIPTION
With a large number of keys, the lruWalk() function becomes a bottleneck by creating a large temporary array.

This simply avoids that array.  V8 is still doing some part of the linear work internally, because it does not become O(1) to key count, but it is 2x faster for 10k keys, and 4x faster for 100k keys.

http://jsperf.com/key-in-vs-object-keys

This also would not measure what should be a small improvement in pause times for the next garbage collection.
