### PR TITLE
Corrected improvements.

### DIFF
--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -42,7 +42,6 @@ function LRUCache (options) {
 
   var cache = {} // hash of items by key
     , lruList = {} // list of items in order of use recency
-    , lru = 0 // least recently used
     , mru = 0 // most recently used
     , length = 0 // number of items in the list
     , itemCount = 0
@@ -104,7 +103,6 @@ function LRUCache (options) {
     }
     cache = {}
     lruList = {}
-    lru = 0
     mru = 0
     length = 0
     itemCount = 0
@@ -153,7 +151,6 @@ function LRUCache (options) {
       return
     }
     delete lruList[hit.lu]
-    if (hit.lu === lru) lruWalk()
     hit.lu = mru ++
     lruList[hit.lu] = hit
     return hit.value
@@ -165,30 +162,21 @@ function LRUCache (options) {
     if (dispose) dispose(key, hit.value)
     delete cache[key]
     delete lruList[hit.lu]
-    if (hit.lu === lru) lruWalk()
     length -= hit.length
     itemCount --
   }
 
-  function lruWalk () {
-    // lru has been deleted, hop up to the next hit.
-    for (var key in lruList) {
-      return key
-    }
-  }
-
   function trim () {
     if (length <= max) return
-    var prune = Object.keys(lruList)
-    for (var i = 0; i < prune.length && length > max; i ++) {
-      var hit = lruList[prune[i]]
+    for (var k in lruList) {
+      if (length <= max) break;
+      if (!hOP(lruList, k)) continue; // protect against wild savages
+      var hit = lruList[k]
       if (dispose) dispose(hit.key, hit.value)
       length -= hit.length
       delete cache[ hit.key ]
-      delete lruList[prune[i]]
+      delete lruList[k]
     }
-
-    lruWalk()
   }
 }
 


### PR DESCRIPTION
Freek Zindel sent along some helpful code review comments that lruWalk actually doesn't do anything, because 'lru' is never used once it gets set.

Since trim() does all the real work, I applied the same basic optimization (avoiding the potentially large temporary array) to the loop inside trim(); along with removing all the unused code.

This removes the temporary array, but does add a call to hasOwnProperty for loop safety.  If you trust we are not in a world of savages (who really extends Object.prototype anymore?), then it could be avoided.
