### PR TITLE
call "dispose()" on objects that fall off the cache because they're too big

### DIFF
--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -135,7 +135,10 @@ function LRUCache (options) {
     }
 
     // oversized objects fall out of cache automatically.
-    if (hit.length > max) return false
+    if (hit.length > max) {
+      if (dispose) dispose(key, value)
+      return false
+    }
 
     length += hit.length
     lruList[hit.lu] = cache[key] = hit

--- a/test/basic.js
+++ b/test/basic.js
@@ -246,3 +246,22 @@ test("disposal function", function(t) {
   t.equal(disposed, 3)
   t.end()
 })
+
+test("disposal function on too big of item", function(t) {
+  var disposed = false
+  var cache = new LRU({
+    max: 1,
+    length: function (k) {
+      return k.length
+    },
+    dispose: function (k, n) {
+      disposed = n
+    }
+  })
+  var obj = [ 1, 2 ]
+
+  t.equal(disposed, false)
+  cache.set("obj", obj)
+  t.equal(disposed, obj)
+  t.end()
+})


### PR DESCRIPTION
This case could be detected manually by checking for a `false` return value,
but it seems to me that there'd be no case where you wouldn't want to call the
"dispose" function when this happens.
