### PR TITLE
New options for 'get', 'set' and 'has'

### DIFF
--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -117,19 +117,21 @@ function LRUCache (options) {
     return cache
   }
 
-  this.set = function (key, value) {
+  this.set = function (key, value, options) {
+    var oMaxAge = options && options.maxAge ? options.maxAge : maxAge
     if (hOP(cache, key)) {
       // dispose of the old one before overwriting
       if (dispose) dispose(key, cache[key].value)
-      if (maxAge) cache[key].now = Date.now()
+      cache[key].now = Date.now()
       cache[key].value = value
+      cache[key].maxAge = oMaxAge
       this.get(key)
       return true
     }
 
     var len = lengthCalculator(value)
-    var age = maxAge ? Date.now() : 0
-    var hit = new Entry(key, value, mru++, len, age)
+    var age = Date.now()
+    var hit = new Entry(key, value, mru++, len, age, oMaxAge)
 
     // oversized objects fall out of cache automatically.
     if (hit.length > max) {
@@ -145,21 +147,28 @@ function LRUCache (options) {
     return true
   }
 
-  this.has = function (key) {
+  this.has = function (key, options) {
     if (!hOP(cache, key)) return false
     var hit = cache[key]
-    if (maxAge && (Date.now() - hit.now > maxAge)) {
+      , oMaxAge = options && options.maxAge ? options.maxAge : Infinity
+      , mMaxAge = Math.min(oMaxAge, hit.maxAge || Infinity)
+    if (Date.now() - hit.now > mMaxAge) {
       return false
     }
     return true
   }
 
-  this.get = function (key) {
+  this.get = function (key, options) {
     if (!hOP(cache, key)) return
     var hit = cache[key]
-    if (maxAge && (Date.now() - hit.now > maxAge)) {
+      , oMaxAge = options && options.maxAge ? options.maxAge : null
+      , lAllowStale = options && typeof options.stale != 'undefined' ? options.stale : allowStale
+    if (hit.maxAge && (Date.now() - hit.now > hit.maxAge)) {
       this.del(key)
-      return allowStale ? hit.value : undefined
+      return lAllowStale ? hit.value : undefined
+    }
+    if (oMaxAge && (Date.now() - hit.now > oMaxAge)) {
+      return
     }
     delete lruList[hit.lu]
     hit.lu = mru ++
@@ -191,12 +200,13 @@ function LRUCache (options) {
 }
 
 // classy, since V8 prefers predictable objects.
-function Entry (key, value, mru, len, age) {
+function Entry (key, value, mru, len, age, maxAge) {
   this.key = key
   this.value = value
   this.lu = mru
   this.length = len
   this.now = age
+  this.maxAge = maxAge
 }
 
 })()


### PR DESCRIPTION
This three methods now accept a new parameter called options.

The new available options are:
- set
  - maxAge: Sets the maxAge for the specific entry.
          This option overrides the global maxAge
- get:
  - maxAge: Does not return values older than maxAge.
          This option does not override the global maxAge or
          the entry maxAge.
  - stale:  Allows or disallows returning stale values per call.
          This option overrides the global stale option
- has
  - maxAge: Does not return true for values older than maxAge.
          This option does not override the global maxAge or
          the entry maxAge
