### PR TITLE
Updated README to accurately describe the 'max' property

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ away.
 
 ## Options
 
-* `max` The maximum number of items.  Not setting this is kind of
+* `max` The maximum size of the cache, checked by applying the length function to all values in the cache.  Not setting this is kind of
   silly, since that's the whole purpose of this lib, but it defaults
   to `Infinity`.
 * `maxAge` Maximum age in ms.  Items are not pro-actively pruned out


### PR DESCRIPTION
The current README says the 'max' property is the maximum number of items, which sounds like the maximum number of keys. Updated the README to reflect what the max is actually checked againts.
