### PR TITLE
Enable npm test without globally installed tap

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.3.1",
   "author": "Isaac Z. Schlueter <i@izs.me>",
   "scripts": {
-    "test": "tap test --gc"
+    "test": "./node_modules/.bin/tap test --gc"
   },
   "main": "lib/lru-cache.js",
   "repository": "git://github.com/isaacs/node-lru-cache.git",


### PR DESCRIPTION
I wanted to run the tests, but didn't have tap installed. This makes it a tiny bit easier.
