### PR TITLE
Switch to function prototype to allow overridden methods

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Trent Mick <trentm@gmail.com>
 Kevin O'Hara <kevinohara80@gmail.com>
 Marco Rogers <marco.rogers@gmail.com>
 Jesse Dailey <jesse.dailey@gmail.com>
+Eli Skeggs <eskeggs@globesherpa.com>

--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -18,98 +18,137 @@ function LRUCache (options) {
     return new LRUCache(options)
   }
 
-  var max
   if (typeof options === 'number') {
-    max = options
-    options = { max: max }
+    options = { max: options }
   }
 
   if (!options) options = {}
 
-  max = options.max
+  this._max = options.max
 
-  var lengthCalculator = options.length || naiveLength
-
-  if (typeof lengthCalculator !== "function") {
-    lengthCalculator = naiveLength
+  if (typeof options.length !== "function") {
+    this._lengthCalculator = naiveLength
+  } else {
+    this._lengthCalculator = options.length
   }
 
-  if (!max || !(typeof max === "number") || max <= 0 ) {
+  if (!this._max || !(typeof this._max === "number") || this._max <= 0) {
     // a little bit silly.  maybe this should throw?
-    max = Infinity
+    this._max = Infinity
   }
 
-  var allowStale = options.stale || false
+  this._allowStale = options.stale || false
 
-  var maxAge = options.maxAge || null
+  this._maxAge = options.maxAge || null
 
-  var dispose = options.dispose
+  this._dispose = options.dispose
 
-  var cache = Object.create(null) // hash of items by key
-    , lruList = Object.create(null) // list of items in order of use recency
-    , mru = 0 // most recently used
-    , lru = 0 // least recently used
-    , length = 0 // number of items in the list
-    , itemCount = 0
-
+  this._cache = Object.create(null) // hash of items by key
+  this._lruList = Object.create(null) // list of items in order of use recency
+  this._mru = 0 // most recently used
+  this._lru = 0 // least recently used
+  this._length = 0 // number of items in the list
+  this._itemCount = 0
 
   // resize the cache when the max changes.
-  Object.defineProperty(this, "max",
-    { set : function (mL) {
-        if (!mL || !(typeof mL === "number") || mL <= 0 ) mL = Infinity
-        max = mL
-        // if it gets above double max, trim right away.
-        // otherwise, do it whenever it's convenient.
-        if (length > max) trim()
-      }
-    , get : function () { return max }
-    , enumerable : true
-    })
+  Object.defineProperty(this, "max", {
+    set: function (mL) {
+      if (!mL || !(typeof mL === "number") || mL <= 0) mL = Infinity
+      this._max = mL
+      // if it gets above double max, trim right away.
+      // otherwise, do it whenever it's convenient.
+      if (this._length > this._max) trim(this)
+    },
+    get: function () { return this._max },
+    enumerable: true
+  })
 
   // resize the cache when the lengthCalculator changes.
-  Object.defineProperty(this, "lengthCalculator",
-    { set : function (lC) {
-        if (typeof lC !== "function") {
-          lengthCalculator = naiveLength
-          length = itemCount
-          for (var key in cache) {
-            cache[key].length = 1
-          }
-        } else {
-          lengthCalculator = lC
-          length = 0
-          for (var key in cache) {
-            cache[key].length = lengthCalculator(cache[key].value)
-            length += cache[key].length
-          }
+  Object.defineProperty(this, "lengthCalculator", {
+    set: function (lC) {
+      if (typeof lC !== "function") {
+        this._lengthCalculator = naiveLength
+        this._length = itemCount
+        for (var key in this._cache) {
+          this._cache[key].length = 1
         }
-
-        if (length > max) trim()
+      } else {
+        this._lengthCalculator = lC
+        this._length = 0
+        for (var key in this._cache) {
+          this._cache[key].length = this._lengthCalculator(this._cache[key].value)
+          this._length += this._cache[key].length
+        }
       }
-    , get : function () { return lengthCalculator }
-    , enumerable : true
-    })
 
-  Object.defineProperty(this, "length",
-    { get : function () { return length }
-    , enumerable : true
-    })
+      if (this._length > max) trim(this)
+    },
+    get: function () { return this._lengthCalculator },
+    enumerable: true
+  })
 
+  Object.defineProperty(this, "length", {
+    get: function () { return this._length },
+    enumerable: true
+  })
 
-  Object.defineProperty(this, "itemCount",
-    { get : function () { return itemCount }
-    , enumerable : true
-    })
+  Object.defineProperty(this, "itemCount", {
+    get: function () { return this._itemCount },
+    enumerable: true
+  })
+}
 
+function get (self, key, doUse) {
+  var hit = self._cache[key]
+  if (hit) {
+    if (self._maxAge && (Date.now() - hit.now > self._maxAge)) {
+      del(self, hit)
+      if (!self._allowStale) hit = undefined
+    } else if (doUse) {
+      use(self, hit)
+    }
+    if (hit) hit = hit.value
+  }
+  return hit
+}
+
+function use (self, hit) {
+  shiftLU(self, hit)
+  hit.lu = self._mru++
+  self._lruList[hit.lu] = hit
+}
+
+function trim (self) {
+  while (self._lru < self._mru && self._length > self._max)
+    del(self, self._lruList[self._lru])
+}
+
+function shiftLU (self, hit) {
+  delete self._lruList[hit.lu]
+  while (self._lru < self._mru && !self._lruList[self._lru]) self._lru++
+}
+
+function del (self, hit) {
+  if (hit) {
+    if (self._dispose) self._dispose(hit.key, hit.value)
+    self._length -= hit.length
+    self._itemCount--
+    delete self._cache[hit.key]
+    shiftLU(self, hit)
+  }
+}
+
+(function() {
   this.forEach = function (fn, thisp) {
     thisp = thisp || this
-    var i = 0;
-    for (var k = mru - 1; k >= 0 && i < itemCount; k--) if (lruList[k]) {
+    var i = 0
+    for (var k = this._mru - 1; k >= 0 && i < this._itemCount; k--)
+    if (this._lruList[k]) {
       i++
-      var hit = lruList[k]
-      if (maxAge && (Date.now() - hit.now > maxAge)) {
-        del(hit)
-        if (!allowStale) hit = undefined
+      var hit = this._lruList[k]
+      if (this._maxAge && (Date.now() - hit.now > this._maxAge)) {
+        del(this, hit)
+        if (!this._allowStale) hit = undefined
       }
       if (hit) {
         fn.call(thisp, hit.value, hit.key, this)
@@ -118,138 +157,100 @@ function LRUCache (options) {
   }
 
   this.keys = function () {
-    var keys = new Array(itemCount)
+    var keys = new Array(this._itemCount)
     var i = 0
-    for (var k = mru - 1; k >= 0 && i < itemCount; k--) if (lruList[k]) {
-      var hit = lruList[k]
+    for (var k = this._mru - 1; k >= 0 && i < this._itemCount; k--)
+    if (this._lruList[k]) {
+      var hit = this._lruList[k]
       keys[i++] = hit.key
     }
     return keys
   }
 
   this.values = function () {
-    var values = new Array(itemCount)
+    var values = new Array(this._itemCount)
     var i = 0
-    for (var k = mru - 1; k >= 0 && i < itemCount; k--) if (lruList[k]) {
-      var hit = lruList[k]
+    for (var k = this._mru - 1; k >= 0 && i < this._itemCount; k--)
+    if (this._lruList[k]) {
+      var hit = this._lruList[k]
       values[i++] = hit.value
     }
     return values
   }
 
   this.reset = function () {
-    if (dispose) {
-      for (var k in cache) {
-        dispose(k, cache[k].value)
+    if (this._dispose) {
+      for (var k in this._cache) {
+        this._dispose(k, this._cache[k].value)
       }
     }
-    cache = {}
-    lruList = {}
-    lru = 0
-    mru = 0
-    length = 0
-    itemCount = 0
+    this._cache = {}
+    this._lruList = {}
+    this._lru = 0
+    this._mru = 0
+    this._length = 0
+    this._itemCount = 0
   }
 
   // Provided for debugging/dev purposes only. No promises whatsoever that
   // this API stays stable.
   this.dump = function () {
-    return cache
+    return this._cache
   }
 
   this.dumpLru = function () {
-    return lruList
+    return this._lruList
   }
 
   this.set = function (key, value) {
-    if (hOP(cache, key)) {
+    if (hOP(this._cache, key)) {
       // dispose of the old one before overwriting
-      if (dispose) dispose(key, cache[key].value)
-      if (maxAge) cache[key].now = Date.now()
-      cache[key].value = value
+      if (this._dispose) this._dispose(key, this._cache[key].value)
+      if (this._maxAge) this._cache[key].now = Date.now()
+      this._cache[key].value = value
       this.get(key)
       return true
     }
 
-    var len = lengthCalculator(value)
-    var age = maxAge ? Date.now() : 0
-    var hit = new Entry(key, value, mru++, len, age)
+    var len = this._lengthCalculator(value)
+    var age = this._maxAge ? Date.now() : 0
+    var hit = new Entry(key, value, this._mru++, len, age)
 
     // oversized objects fall out of cache automatically.
-    if (hit.length > max) {
-      if (dispose) dispose(key, value)
+    if (hit.length > this._max) {
+      if (this._dispose) this._dispose(key, value)
       return false
     }
 
-    length += hit.length
-    lruList[hit.lu] = cache[key] = hit
-    itemCount ++
+    this._length += hit.length
+    this._lruList[hit.lu] = this._cache[key] = hit
+    this._itemCount++
 
-    if (length > max) trim()
+    if (this._length > this._max) trim(this)
     return true
   }
 
   this.has = function (key) {
-    if (!hOP(cache, key)) return false
-    var hit = cache[key]
-    if (maxAge && (Date.now() - hit.now > maxAge)) {
+    if (!hOP(this._cache, key)) return false
+    var hit = this._cache[key]
+    if (this._maxAge && (Date.now() - hit.now > this._maxAge)) {
       return false
     }
     return true
   }
 
   this.get = function (key) {
-    return get(key, true)
+    return get(this, key, true)
   }
 
   this.peek = function (key) {
-    return get(key, false)
-  }
-
-  function get (key, doUse) {
-    var hit = cache[key]
-    if (hit) {
-      if (maxAge && (Date.now() - hit.now > maxAge)) {
-        del(hit)
-        if (!allowStale) hit = undefined
-      } else {
-        if (doUse) use(hit)
-      }
-      if (hit) hit = hit.value
-    }
-    return hit
-  }
-
-  function use (hit) {
-    shiftLU(hit)
-    hit.lu = mru ++
-    lruList[hit.lu] = hit
+    return get(this, key, false)
   }
 
   this.del = function (key) {
-    del(cache[key])
+    del(this, this._cache[key])
   }
-
-  function trim () {
-    while (lru < mru && length > max)
-      del(lruList[lru])
-  }
-
-  function shiftLU(hit) {
-    delete lruList[ hit.lu ]
-    while (lru < mru && !lruList[lru]) lru ++
-  }
-
-  function del(hit) {
-    if (hit) {
-      if (dispose) dispose(hit.key, hit.value)
-      length -= hit.length
-      itemCount --
-      delete cache[ hit.key ]
-      shiftLU(hit)
-    }
-  }
-}
+}).call(LRUCache.prototype)
 
 // classy, since V8 prefers predictable objects.
 function Entry (key, value, mru, len, age) {


### PR DESCRIPTION
I extended lru-cache for use in another project, but found that my prototypal methods did not override the methods on lru-cache, because the methods are defined on the object itself, and not on the prototype. This commit switches the method definitions to `LRUCache`'s prototype so that other prototypes can inherit from `LRUCache`.

This pull request passes all tests, should not affect usage or API, and appears to have little to no effect on the benchmarks (correct me if I'm wrong and I'll see what I can do).
