### PR TITLE
Use null-prototype'd objects in reset()

### DIFF
--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -143,8 +143,8 @@ function LRUCache (options) {
         dispose(k, cache[k].value)
       }
     }
-    cache = {}
-    lruList = {}
+    cache = Object.create(null)
+    lruList = Object.create(null)
     lru = 0
     mru = 0
     length = 0


### PR DESCRIPTION
Fixed `reset` behaviour to match constructor.
