### PR TITLE
Add cache.pop(), which evicts the oldest item, without affecting "max"

### DIFF
--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -206,6 +206,12 @@ function LRUCache (options) {
     return get(key, false)
   }
 
+  this.pop = function () {
+    var hit = lruList[lru]
+    del(hit)
+    return hit || null
+  }
+
   function get (key, doUse) {
     var hit = cache[key]
     if (hit) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -327,3 +327,43 @@ test("least recently set w/ peek", function (t) {
   t.equal(cache.get("a"), undefined)
   t.end()
 })
+
+test("pop the least used item", function (t) {
+  var cache = new LRU(3)
+  , last
+
+  cache.set("a", "A")
+  cache.set("b", "B")
+  cache.set("c", "C")
+
+  t.equal(cache.length, 3)
+  t.equal(cache.max, 3)
+
+  // Ensure we pop a, c, b
+  cache.get("b", "B")
+
+  last = cache.pop()
+  t.equal(last.key, "a")
+  t.equal(last.value, "A")
+  t.equal(cache.length, 2)
+  t.equal(cache.max, 3)
+
+  last = cache.pop()
+  t.equal(last.key, "c")
+  t.equal(last.value, "C")
+  t.equal(cache.length, 1)
+  t.equal(cache.max, 3)
+
+  last = cache.pop()
+  t.equal(last.key, "b")
+  t.equal(last.value, "B")
+  t.equal(cache.length, 0)
+  t.equal(cache.max, 3)
+
+  last = cache.pop()
+  t.equal(last, null)
+  t.equal(cache.length, 0)
+  t.equal(cache.max, 3)
+
+  t.end()
+})


### PR DESCRIPTION
What the title says. I didn't bump version in package.json.
