### PR TITLE
forEach iterates over all entries when an entry is deleted

### DIFF
--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -86,8 +86,10 @@ Object.defineProperty(LRUCache.prototype, "itemCount",
 
 LRUCache.prototype.forEach = function (fn, thisp) {
   thisp = thisp || this
-  var i = 0;
-  for (var k = this._mru - 1; k >= 0 && i < this._itemCount; k--) if (this._lruList[k]) {
+  var i = 0
+  var itemCount = this._itemCount
+
+  for (var k = this._mru - 1; k >= 0 && i < itemCount; k--) if (this._lruList[k]) {
     i++
     var hit = this._lruList[k]
     if (this._maxAge && (Date.now() - hit.now > this._maxAge)) {

--- a/test/foreach.js
+++ b/test/foreach.js
@@ -50,3 +50,40 @@ test('keys() and values()', function (t) {
 
   t.end()
 })
+
+test('all entries are iterated over', function(t) {
+  var l = new LRU(5)
+  for (var i = 0; i < 10; i ++) {
+    l.set(i.toString(), i.toString(2))
+  }
+
+  var i = 0
+  l.forEach(function (val, key, cache) {
+    if (i > 0) {
+      cache.del(key)
+    }
+    i += 1
+  })
+
+  t.equal(i, 5)
+  t.equal(l.keys().length, 1)
+
+  t.end()
+})
+
+test('all stale entries are removed', function(t) {
+  var l = new LRU({ max: 5, maxAge: -5, stale: true })
+  for (var i = 0; i < 10; i ++) {
+    l.set(i.toString(), i.toString(2))
+  }
+
+  var i = 0
+  l.forEach(function () {
+    i += 1
+  })
+
+  t.equal(i, 5)
+  t.equal(l.keys().length, 0)
+
+  t.end()
+})


### PR DESCRIPTION
forEach now continues if an item is deleted from the cache whilst iterating over it, fixing issue #33. 

A consequence of this change is if one adds an entry during the forEach it will *not* be iterated over. If this behaviour is wanted a check could be added sometime after the fn.call(...) inside the for loop e.g.
```
if (this._itemCount > itemCount) {
  itemCount = this._itemCount
}
```