### PR TITLE
Infinity is not valid as max value

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ away.
 * `max` The maximum size of the cache, checked by applying the length
   function to all values in the cache.  Not setting this is kind of
   silly, since that's the whole purpose of this lib, but it defaults
-  to `Infinity`.
+  to `Number.MAX_VALUE`.
 * `maxAge` Maximum age in ms.  Items are not pro-actively pruned out
   as they age, but if you try to get an item that is too old, it'll
   drop it and return undefined instead of giving it to you.

--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -24,9 +24,9 @@ function LRUCache (options) {
     options = {}
 
   this._max = options.max
-  // Kind of weird to have a default max of Infinity, but oh well.
-  if (!this._max || !(typeof this._max === "number") || this._max <= 0 )
-    this._max = Infinity
+  // Kind of weird to have a default max of Number.MAX_VALUE, but oh well.
+  if (!this._max || !(typeof this._max === "number") || this._max <= 0 || this._max > Number.MAX_VALUE)
+    this._max = Number.MAX_VALUE
 
   this._lengthCalculator = options.length || naiveLength
   if (typeof this._lengthCalculator !== "function")
@@ -41,7 +41,7 @@ function LRUCache (options) {
 // resize the cache when the max changes.
 Object.defineProperty(LRUCache.prototype, "max",
   { set : function (mL) {
-      if (!mL || !(typeof mL === "number") || mL <= 0 ) mL = Infinity
+      if (!mL || !(typeof mL === "number") || mL <= 0 || ml > Number.MAX_VALUE) mL = Number.MAX_VALUE
       this._max = mL
       if (this._length > this._max) trim(this)
     }


### PR DESCRIPTION
Dumb fix...

In a very hypothetical edge case reaching the max capacity, the cache will never be trimmed, cause Numbers larger than `Number.MAX_VALUE` are represented as `Infinity` and the following condition will fail
https://github.com/isaacs/node-lru-cache/blob/v2.6.2/lib/lru-cache.js#L175-L180
