### PR TITLE
Fix performance regression on Node 4x

### DIFF
--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -7,10 +7,6 @@ if (typeof module === 'object' && module.exports) {
   this.LRUCache = LRUCache
 }
 
-function hOP (obj, key) {
-  return Object.prototype.hasOwnProperty.call(obj, key)
-}
-
 function naiveLength () { return 1 }
 
 function LRUCache (options) {
@@ -55,15 +51,15 @@ Object.defineProperty(LRUCache.prototype, "lengthCalculator",
       if (typeof lC !== "function") {
         this._lengthCalculator = naiveLength
         this._length = this._itemCount
-        for (var key in this._cache) {
-          this._cache[key].length = 1
+        for (var value of this._cache.values()) {
+          value.length = 1
         }
       } else {
         this._lengthCalculator = lC
         this._length = 0
-        for (var key in this._cache) {
-          this._cache[key].length = this._lengthCalculator(this._cache[key].value)
-          this._length += this._cache[key].length
+        for (var value of this._cache.values()) {
+          value.length = this._lengthCalculator(value.value)
+          this._length += value.length
         }
       }
 
@@ -89,9 +85,9 @@ LRUCache.prototype.forEach = function (fn, thisp) {
   var i = 0
   var itemCount = this._itemCount
 
-  for (var k = this._mru - 1; k >= 0 && i < itemCount; k--) if (this._lruList[k]) {
+  for (var k = this._mru - 1; k >= 0 && i < itemCount; k--) if (this._lruList.has(k)) {
     i++
-    var hit = this._lruList[k]
+    var hit = this._lruList.get(k)
     if (isStale(this, hit)) {
       del(this, hit)
       if (!this._allowStale) hit = undefined
@@ -105,8 +101,8 @@ LRUCache.prototype.forEach = function (fn, thisp) {
 LRUCache.prototype.keys = function () {
   var keys = new Array(this._itemCount)
   var i = 0
-  for (var k = this._mru - 1; k >= 0 && i < this._itemCount; k--) if (this._lruList[k]) {
-    var hit = this._lruList[k]
+  for (var k = this._mru - 1; k >= 0 && i < this._itemCount; k--) if (this._lruList.has(k)) {
+    var hit = this._lruList.get(k)
     keys[i++] = hit.key
   }
   return keys
@@ -115,8 +111,8 @@ LRUCache.prototype.keys = function () {
 LRUCache.prototype.values = function () {
   var values = new Array(this._itemCount)
   var i = 0
-  for (var k = this._mru - 1; k >= 0 && i < this._itemCount; k--) if (this._lruList[k]) {
-    var hit = this._lruList[k]
+  for (var k = this._mru - 1; k >= 0 && i < this._itemCount; k--) if (this._lruList.has(k)) {
+    var hit = this._lruList.get(k)
     values[i++] = hit.value
   }
   return values
@@ -124,13 +120,13 @@ LRUCache.prototype.values = function () {
 
 LRUCache.prototype.reset = function () {
   if (this._dispose && this._cache) {
-    for (var k in this._cache) {
-      this._dispose(k, this._cache[k].value)
+    for (var entry of this._cache) {
+      this._dispose(entry[0], entry[1].value)
     }
   }
 
-  this._cache = Object.create(null) // hash of items by key
-  this._lruList = Object.create(null) // list of items in order of use recency
+  this._cache = new Map() // hash of items by key
+  this._lruList = new Map() // list of items in order of use recency
   this._mru = 0 // most recently used
   this._lru = 0 // least recently used
   this._length = 0 // number of items in the list
@@ -141,8 +137,8 @@ LRUCache.prototype.dump = function () {
   var arr = []
   var i = 0
 
-  for (var k = this._mru - 1; k >= 0 && i < this._itemCount; k--) if (this._lruList[k]) {
-    var hit = this._lruList[k]
+  for (var k = this._mru - 1; k >= 0 && i < this._itemCount; k--) if (this._lruList.has(k)) {
+    var hit = this._lruList.get(k)
     if (!isStale(this, hit)) {
       //Do not store staled hits
       ++i
@@ -162,24 +158,31 @@ LRUCache.prototype.dumpLru = function () {
 }
 
 LRUCache.prototype.set = function (key, value, maxAge) {
+  // Map allows any type of `key` (objects, number, etc). For backwards
+  // compatibility, coerce to a string.
+  key = String(key)
+
   maxAge = maxAge || this._maxAge
   var now = maxAge ? Date.now() : 0
   var len = this._lengthCalculator(value)
 
-  if (hOP(this._cache, key)) {
+  if (this._cache.has(key)) {
     if (len > this._max) {
-      del(this, this._cache[key])
+      del(this, this._cache.get(key))
       return false
     }
+
+    var item = this._cache.get(key)
+
     // dispose of the old one before overwriting
     if (this._dispose)
-      this._dispose(key, this._cache[key].value)
+      this._dispose(key, item.value)
 
-    this._cache[key].now = now
-    this._cache[key].maxAge = maxAge
-    this._cache[key].value = value
-    this._length += (len - this._cache[key].length)
-    this._cache[key].length = len
+    item.now = now
+    item.maxAge = maxAge
+    item.value = value
+    this._length += (len - item.length)
+    item.length = len
     this.get(key)
 
     if (this._length > this._max)
@@ -197,7 +200,8 @@ LRUCache.prototype.set = function (key, value, maxAge) {
   }
 
   this._length += hit.length
-  this._lruList[hit.lu] = this._cache[key] = hit
+  this._cache.set(key, hit)
+  this._lruList.set(hit.lu, hit)
   this._itemCount ++
 
   if (this._length > this._max)
@@ -207,8 +211,8 @@ LRUCache.prototype.set = function (key, value, maxAge) {
 }
 
 LRUCache.prototype.has = function (key) {
-  if (!hOP(this._cache, key)) return false
-  var hit = this._cache[key]
+  if (!this._cache.has(key)) return false
+  var hit = this._cache.get(key)
   if (isStale(this, hit)) {
     return false
   }
@@ -224,13 +228,13 @@ LRUCache.prototype.peek = function (key) {
 }
 
 LRUCache.prototype.pop = function () {
-  var hit = this._lruList[this._lru]
+  var hit = this._lruList.get(this._lru)
   del(this, hit)
   return hit || null
 }
 
 LRUCache.prototype.del = function (key) {
-  del(this, this._cache[key])
+  del(this, this._cache.get(key))
 }
 
 LRUCache.prototype.load = function (arr) {
@@ -254,7 +258,11 @@ LRUCache.prototype.load = function (arr) {
 }
 
 function get (self, key, doUse) {
-  var hit = self._cache[key]
+  // Map allows any type of `key` (objects, number, etc). For backwards
+  // compatibility, coerce to a string.
+  key = String(key)
+
+  var hit = self._cache.get(key)
   if (hit) {
     if (isStale(self, hit)) {
       del(self, hit)
@@ -282,17 +290,17 @@ function isStale(self, hit) {
 function use (self, hit) {
   shiftLU(self, hit)
   hit.lu = self._mru ++
-  self._lruList[hit.lu] = hit
+  self._lruList.set(hit.lu, hit)
 }
 
 function trim (self) {
   while (self._lru < self._mru && self._length > self._max)
-    del(self, self._lruList[self._lru])
+    del(self, self._lruList.get(self._lru))
 }
 
 function shiftLU (self, hit) {
-  delete self._lruList[ hit.lu ]
-  while (self._lru < self._mru && !self._lruList[self._lru]) self._lru ++
+  self._lruList.delete(hit.lu)
+  while (self._lru < self._mru && !self._lruList.has(self._lru)) self._lru ++
 }
 
 function del (self, hit) {
@@ -300,7 +308,7 @@ function del (self, hit) {
     if (self._dispose) self._dispose(hit.key, hit.value)
     self._length -= hit.length
     self._itemCount --
-    delete self._cache[ hit.key ]
+    self._cache.delete(hit.key)
     shiftLU(self, hit)
   }
 }


### PR DESCRIPTION
see #54

Note: This is a forwards compatible only change, it works on any NodeJS/iojs release with `Map` support. Using plain objects isn't working well on NodeJS 4.0 - 4.2.1. See #54 for details. Not sure if this is the direction you'd like to go for this module but it seems to me the alternatives are:

1. wait for V8 to fix the bug (or fix it ourselves). In the meantime put a disclaimer on the README
2. use a different module
3. this PR
4. use another fancier approach, like maybe use multiple cache objects with some manual sharding to keep < 8193 keys per cache object
5. ?

RE: failed tests - some fail due to c++ build failure.

