### PR TITLE
Ensure cache/lru stores are treated as dictionaries by v8

### DIFF
--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -135,6 +135,14 @@ LRUCache.prototype.reset = function () {
   this._lru = 0 // least recently used
   this._length = 0 // number of items in the list
   this._itemCount = 0
+
+  // Ensure the cache/lru stores are treated as dictionaries
+  // Otherwise a pathological case can occur in v8 that degrades performance
+  // See https://github.com/isaacs/node-lru-cache/issues/54 and
+  // https://code.google.com/p/v8/issues/detail?id=4518 for more details
+  this._cache[200000] = this._lruList[200000] = true
+  delete this._cache[200000]
+  delete this._lruList[200000]
 }
 
 LRUCache.prototype.dump = function () {


### PR DESCRIPTION
Ensure the cache/lru stores are treated as dictionaries. Otherwise a
pathological case can occur in v8 that degrades performance.

See https://github.com/isaacs/node-lru-cache/issues/54 and
https://code.google.com/p/v8/issues/detail?id=4518 for more details

Thanks to @aheckmann for the report and @ofrobots for the fix.

Fixes #54