### PR TITLE
Only accept strings and numbers as keys (#53)

### DIFF
--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -13,6 +13,12 @@ function hOP (obj, key) {
 
 function naiveLength () { return 1 }
 
+function typeCheckKey(key) {
+  if (typeof key !== 'string' && typeof key !== 'number') {
+    throw new TypeError("key must be a string or number! received " + key + " as " + typeof key)
+  }
+}
+
 function LRUCache (options) {
   if (!(this instanceof LRUCache))
     return new LRUCache(options)
@@ -163,6 +169,8 @@ LRUCache.prototype.dumpLru = function () {
 
 LRUCache.prototype.set = function (key, value, maxAge) {
   maxAge = maxAge || this._maxAge
+  typeCheckKey(key)
+
   var now = maxAge ? Date.now() : 0
   var len = this._lengthCalculator(value)
 
@@ -207,6 +215,7 @@ LRUCache.prototype.set = function (key, value, maxAge) {
 }
 
 LRUCache.prototype.has = function (key) {
+  typeCheckKey(key)
   if (!hOP(this._cache, key)) return false
   var hit = this._cache[key]
   if (isStale(this, hit)) {
@@ -216,10 +225,12 @@ LRUCache.prototype.has = function (key) {
 }
 
 LRUCache.prototype.get = function (key) {
+  typeCheckKey(key)
   return get(this, key, true)
 }
 
 LRUCache.prototype.peek = function (key) {
+  typeCheckKey(key)
   return get(this, key, false)
 }
 
@@ -230,6 +241,7 @@ LRUCache.prototype.pop = function () {
 }
 
 LRUCache.prototype.del = function (key) {
+  typeCheckKey(key)
   del(this, this._cache[key])
 }
 
@@ -241,6 +253,7 @@ LRUCache.prototype.load = function (arr) {
   //A previous serialized cache has the most recent items first
   for (var l = arr.length - 1; l >= 0; l-- ) {
     var hit = arr[l]
+    typeCheckKey(hit.k)
     var expiresAt = hit.e || 0
     if (expiresAt === 0) {
       //the item was created without expiration in a non aged cache
@@ -254,6 +267,7 @@ LRUCache.prototype.load = function (arr) {
 }
 
 function get (self, key, doUse) {
+  typeCheckKey(key)
   var hit = self._cache[key]
   if (hit) {
     if (isStale(self, hit)) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -229,7 +229,7 @@ test("drop the old items", function(t) {
   }, 155)
 })
 
-test("individual item can have it's own maxAge", function(t) {
+test("individual item can have its own maxAge", function(t) {
   var cache = new LRU({
     max: 5,
     maxAge: 50
@@ -242,7 +242,7 @@ test("individual item can have it's own maxAge", function(t) {
   }, 25)
 })
 
-test("individual item can have it's own maxAge > cache's", function(t) {
+test("individual item can have its own maxAge > cache's", function(t) {
   var cache = new LRU({
     max: 5,
     maxAge: 20
@@ -391,6 +391,95 @@ test("pop the least used item", function (t) {
   t.equal(last, null)
   t.equal(cache.length, 0)
   t.equal(cache.max, 3)
+
+  t.end()
+})
+
+test("get and set only accepts strings and numbers as keys", function(t) {
+  var cache = new LRU()
+
+  cache.set("key", "value")
+  cache.set(123, 456)
+
+  t.equal(cache.get("key"), "value")
+  t.equal(cache.get(123), 456)
+
+  t.throws(function() {
+    cache.set({ someObjectKey: true }, "a")
+  }, "set should not accept objects as keys")
+
+  t.throws(function() {
+    cache.get({ someObjectKey: true })
+  }, "get should not accept objects as keys")
+
+  t.throws(function() {
+    cache.set([1,2,3], "b")
+  }, "set should not accept arrays as keys")
+
+  t.throws(function() {
+    cache.get([1,2,3])
+  }, "get should not accept arrays as keys")
+
+  t.end()
+})
+
+test("peek only accepts strings and numbers as keys", function(t) {
+  var cache = new LRU()
+
+  cache.set("key", "value")
+  cache.set(123, 456)
+
+  t.equal(cache.peek("key"), "value")
+  t.equal(cache.peek(123), 456)
+
+  t.throws(function() {
+    cache.peek({ someObjectKey: true })
+  }, "peek should not accept objects as keys")
+
+  t.throws(function() {
+    cache.peek([1,2,3])
+  }, "peek should not accept arrays as keys")
+
+  t.end()
+})
+
+test("del only accepts strings and numbers as keys", function(t) {
+  var cache = new LRU()
+
+  cache.set("key", "value")
+  cache.set(123, 456)
+
+  cache.del("key")
+  cache.del(123)
+
+  t.assertNot(cache.has("key"))
+  t.assertNot(cache.has(123))
+
+  t.throws(function() {
+    cache.del({ someObjectKey: true })
+  }, "del should not accept objects as keys")
+
+  t.throws(function() {
+    cache.del([1,2,3])
+  }, "del should not accept arrays as keys")
+
+  t.end()
+})
+
+
+test("has only accepts strings and numbers as keys", function(t) {
+  var cache = new LRU()
+
+  cache.has("key")
+  cache.has(123)
+
+  t.throws(function() {
+    cache.has({ someObjectKey: true })
+  }, "has should not accept objects as keys")
+
+  t.throws(function() {
+    cache.has([1,2,3])
+  }, "has should not accept arrays as keys")
 
   t.end()
 })

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -13,6 +13,14 @@ test('dump', function (t) {
     { k: "a", v: "A", e: 0 }
   ])
 
+  cache.set(123, 456)
+  t.deepEqual(cache.dump(), [
+    { k: 123, v: 456, e: 0 },
+    { k: "b", v: "B", e: 0 },
+    { k: "a", v: "A", e: 0 },
+  ])
+  cache.del(123)
+
   cache.set("a", "A");
   t.deepEqual(cache.dump(), [
     { k: "a", v: "A", e: 0 },
@@ -88,6 +96,7 @@ test("load basic cache", function(t) {
 
   cache.set("a", "A")
   cache.set("b", "B")
+  cache.set(123, 456)
 
   copy.load(cache.dump())
   t.deepEquals(cache.dump(), copy.dump())
@@ -214,3 +223,24 @@ test("load to other age cache", function(t) {
 
 })
 
+test("type checking of keys during load", function(t) {
+  var cache = new LRU()
+
+  t.throws(function() {
+    cache.load([{
+      k: { someObjectKey: true },
+      v: "B",
+      e: 0
+    }])
+  }, "load should not accept objects as keys")
+
+  t.throws(function() {
+    cache.load([{
+      k: [1,2,3],
+      v: "C",
+      e: 0
+    }])
+  }, "load should not accept arrays as keys")
+
+  t.end()
+})


### PR DESCRIPTION
Here's the long-overdue PR from #53 ! 

We only discussed strings in #53, but I included numbers too; some tests used numbers as keys, and they seem to work just fine.

What are your thoughts on using Symbols as keys? I'm open to making changes to this PR to add in Symbol. It seems like it's probably worth the work, but I wanted to check first.