### PR TITLE
add noDisposeOnSet option

### DIFF
--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -12,6 +12,7 @@ var Yallist = require('yallist')
 var symbols = {}
 var hasSymbol = typeof Symbol === 'function'
 var makeSymbol
+/* istanbul ignore if */
 if (hasSymbol) {
   makeSymbol = function (key) {
     return Symbol.for(key)

--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -78,6 +78,7 @@ function LRUCache (options) {
   priv(this, 'allowStale', options.stale || false)
   priv(this, 'maxAge', options.maxAge || 0)
   priv(this, 'dispose', options.dispose)
+  priv(this, 'noDisposeOnSet', options.noDisposeOnSet || false)
   this.reset()
 }
 
@@ -313,7 +314,7 @@ LRUCache.prototype.set = function (key, value, maxAge) {
     var item = node.value
 
     // dispose of the old one before overwriting
-    if (priv(this, 'dispose')) {
+    if (priv(this, 'dispose') && !priv(this, 'noDisposeOnSet')) {
       priv(this, 'dispose').call(this, key, item.value)
     }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -299,6 +299,22 @@ test('disposal function', function (t) {
   t.end()
 })
 
+test('no dispose on set', function (t) {
+  var disposed = false
+  var cache = new LRU({
+    max: 1,
+    noDisposeOnSet: true,
+    dispose: function (k, n) {
+      disposed = n
+    }
+  })
+
+  cache.set(1, 1)
+  cache.set(1, 10)
+  t.equal(disposed, false)
+  t.end()
+})
+
 test('disposal function on too big of item', function (t) {
   var disposed = false
   var cache = new LRU({


### PR DESCRIPTION
Hi,

in my use case, i need to persist evicted values so i use a "dispose" function. But i don't want "dispose" to be called when i update a key in cache (which may be quite often).

So i add a noDisposeOnSet option.

When set to true, dispose is not called on set. When set to false or not set, behavior is not changed.

Thanks.
