### PR TITLE
Reduce npm payload size by adding .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+test/
+coverage/
+benchmarks/
+nyc_output/
+.nyc_output/
+CONTRIBUTORS
+.npmignore
+.travis.yml


### PR DESCRIPTION
Thanks for creating a module I used every day! I'm trying to give back in whatever little way I can.

The npm payload delivered from `npm install lru-cache` contains a few files which are not needed for the module to actually work. These can be exclude via an [`.npmignore` file](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package). Here is the data for your package before and after an `.npmignore` file:

|  | Including deps | Excluding deps |
| :---: | :---: | :---: |
| Current | 152K KB | 80 KB |
| Updated | 104 KB | 32 KB |
| **Savings** | **31.58%** | **60.00%** |

*I got these numbers using `du -shk <directory>`*

The difference between the "Including / Excluding deps" columns is whether or not the `node_modules/` directory containing `lru-cache`'s dependencies is included.

[According to `lru-cache`'s npmjs.com page](https://www.npmjs.com/package/lru-cache), `lru-cache` has been downloaded 674,130 times in the last day. At 80 KB per download (ignoring `lru-cache`'s dependencies), that is 53.9 GB per day for this module alone! With this change, that number drops by 60.00% to 21.6 GB!

In case you want to double check the resulting package, you can do so locally:

```
# Create a tarball of the resulting package
$ npm pack

# See the file list of that tarball
$ tar -tf lru-cache-<version>.tgz
package/package.json
package/README.md
package/LICENSE
package/lib/lru-cache.js

# Install the tarball as a local node module
$ npm install lru-cache-<version>.tgz
```