### PR TITLE
Add support for max = 0.

### DIFF
--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -64,9 +64,8 @@ function LRUCache (options) {
 
   var max = priv(this, 'max', options.max)
   // Kind of weird to have a default max of Infinity, but oh well.
-  if (!max ||
-      !(typeof max === 'number') ||
-      max <= 0) {
+  if (!(typeof max === 'number') ||
+      max < 0) {
     priv(this, 'max', Infinity)
   }
 
@@ -85,7 +84,7 @@ function LRUCache (options) {
 // resize the cache when the max changes.
 Object.defineProperty(LRUCache.prototype, 'max', {
   set: function (mL) {
-    if (!mL || !(typeof mL === 'number') || mL <= 0) {
+    if (!(typeof mL === 'number') || mL < 0) {
       mL = Infinity
     }
     priv(this, 'max', mL)
@@ -435,14 +434,19 @@ function isStale (self, hit) {
 
 function trim (self) {
   if (priv(self, 'length') > priv(self, 'max')) {
-    for (var walker = priv(self, 'lruList').tail;
-         priv(self, 'length') > priv(self, 'max') && walker !== null;) {
-      // We know that we're about to delete this one, and also
-      // what the next least recently used key will be, so just
-      // go ahead and set it now.
-      var prev = walker.prev
-      del(self, walker)
-      walker = prev
+    if (priv(self, 'max') === 0) {
+      // optimization for dumping entire contents of LRU cache
+      self.reset()
+    } else {
+      for (var walker = priv(self, 'lruList').tail;
+           priv(self, 'length') > priv(self, 'max') && walker !== null;) {
+        // We know that we're about to delete this one, and also
+        // what the next least recently used key will be, so just
+        // go ahead and set it now.
+        var prev = walker.prev
+        del(self, walker)
+        walker = prev
+      }
     }
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -79,6 +79,13 @@ test('max', function (t) {
   for (i = 98; i < 100; i++) {
     t.equal(cache.get(i), i)
   }
+  // test that changing the max to 0 will evict everything
+  cache.max = 0
+  t.equal(cache.max, 0)
+  t.equal(cache.length, 0)
+  for (i = 0; i < 100; i++) {
+    t.equal(cache.get(i), undefined)
+  }
   t.end()
 })
 

--- a/test/inspect.js
+++ b/test/inspect.js
@@ -38,7 +38,7 @@ setTimeout(function () {
   l.lengthCalculator = function () { return 5 }
   inspect('LRUCache {\n  allowStale: true,\n  max: 10,\n  length: 5,\n\n  1 => { value: { a: { b: [Object] } }, length: 5 }\n}')
 
-  l.max = 0
+  l.max = Infinity
   inspect('LRUCache {\n  allowStale: true,\n  length: 5,\n\n  1 => { value: { a: { b: [Object] } }, length: 5 }\n}')
 
   l.maxAge = 100
@@ -51,4 +51,7 @@ setTimeout(function () {
 
   l.lengthCalculator = null
   inspect('LRUCache {\n  1 => { value: { a: { b: [Object] } } }\n}')
+
+  l.max = 0
+  inspect('LRUCache {}')
 }, 100)


### PR DESCRIPTION
It is often useful to have a 0-sized LRU cache to implement a pinned LRU cache
on top, to determine how much unpinned room there is in the LRU cache.