### PR TITLE
add itemManager option and implement CacheItemManager/SessionItemManager

### DIFF
--- a/CacheItemManager.js
+++ b/CacheItemManager.js
@@ -1,0 +1,17 @@
+exports = module.exports = function(cache) {
+  var _cache = cache;
+
+  this.update = function(item, value, maxAge) {
+    maxAge  = maxAge || _cache.maxAge
+    var now = maxAge ? Date.now() : 0
+    
+    // update item
+    item.now    = now
+    item.maxAge = maxAge
+    item.value  = value
+  }
+
+  this.touch = function(item) {
+    // nothing to do
+  }
+}

--- a/SessionItemManager.js
+++ b/SessionItemManager.js
@@ -1,0 +1,19 @@
+exports = module.exports = function(cache) {
+  var _cache = cache;
+
+  this.update = function(item, value, maxAge) {
+    maxAge  = maxAge || item.maxAge
+    var now = maxAge ? Date.now() : 0
+
+    // update item
+    item.now    = now
+    item.maxAge = maxAge
+    item.value  = value
+  }
+
+  this.touch = function(item) {
+    if (item.maxAge) {
+      item.now = Date.now()
+    }
+  }
+};


### PR DESCRIPTION
I add the **itemManager** option and implement two itemManager types CacheItemManager/SessionItemManager.

The `CacheItemManager` is default itemManager all behaviors as original.
The `SessionItemManager` can be used on http session module. the following are the differences:
  * when client call LRUCache.set( _existed_key_, _maxAge_  )
     It will update the "recently used"-ness of the key. `maxAge` is optional and overrides the cache maxAge option if provided; otherwise will be assigned as original maxAge.
  * when client call LRUCache.get( _existed_key_ )
     It will update the "recently used"-ness of the key and renew the expire time with original maxAge + current time.

The itemManager can be implemented easily. It required to implement two functions, 
  * update(item, value, maxAge)
    implement the function when client update the item using the LRUCache.set( _existed_key_, _value_ ) method.
    - `item` the item will be updated.
    - `value` the new value for the item.
    - `maxAge` the new maxAge for the item.
  * touch(item)
    implement the function when client get the item using the LRUCache.get( _existed_key_ ) method.
    - `item` the item will be gotten.

```javascript
exports = module.exports = function(cache) {
  var _cache = cache;

  // implement the function when client update the item 
  // using the LRUCache.set( _existed_key_, _value_ ) method.
  this.update = function(item, value, maxAge) {
    maxAge  = maxAge || _cache.maxAge
    var now = maxAge ? Date.now() : 0
    
    // update item
    item.now    = now
    item.maxAge = maxAge
    item.value  = value
  }

  // implement the function when client get the item using
  // the LRUCache.get( _existed_key_ ) method.
  this.touch = function(item) {
    // nothing to do
  }
}
```

