### PR TITLE
check for Symbol.for instead of just Symbol

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var util = require('util')
 var Yallist = require('yallist')
 
 // use symbols if possible, otherwise just _props
-var hasSymbol = typeof Symbol === 'function'
+var hasSymbol = typeof Symbol === 'function' && typeof Symbol.for === 'function'
 var makeSymbol
 if (hasSymbol) {
   makeSymbol = function (key) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,35 +2,12 @@
   "name": "lru-cache",
   "version": "4.1.2",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
-    "abbrev": {
-      "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-      "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
-      "dev": true
-    },
-    "acorn": {
-      "version": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-      "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
-      "dev": true
-    },
-    "align-text": {
-      "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-      "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
-      "dev": true
-    },
-    "alter": {
-      "version": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-      "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
-      "dev": true
-    },
-    "amdefine": {
-      "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
-      "dev": true
-    },
-    "ansi-escapes": {
-      "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz",
-      "integrity": "sha1-IWCO3TpPxaVow7jYPtSswonV7Hc=",
+    "acorn-to-esprima": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/acorn-to-esprima/-/acorn-to-esprima-2.0.8.tgz",
+      "integrity": "sha1-AD8MZC65ITL0F9NwjxStqCrfLrE=",
       "dev": true
     },
     "ansi-regex": {
@@ -46,27 +23,11 @@
     "argparse": {
       "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
       "integrity": "sha1-FDid7rDCj8TNqUBbn1MqTjeFzoQ=",
-      "dev": true
-    },
-    "array-union": {
-      "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-      "integrity": "sha1-TUEPyDlcskdjcSS63p4/VH1dVfI=",
-      "dev": true
-    },
-    "array-uniq": {
-      "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-      "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
-      "integrity": "sha1-H8HRVk7hFiDfym1nAphQkT+fRnk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+        "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+      }
     },
     "asn1": {
       "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -76,21 +37,6 @@
     "assert-plus": {
       "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "dev": true
-    },
-    "ast-traverse": {
-      "version": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
-      "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY=",
-      "dev": true
-    },
-    "ast-types": {
-      "version": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
-      "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
-      "dev": true
-    },
-    "async": {
-      "version": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
-      "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM=",
       "dev": true
     },
     "asynckit": {
@@ -108,110 +54,196 @@
       "integrity": "sha1-Cin/t5wxyecS7rCH6OemS0pW11U=",
       "dev": true
     },
-    "babel-core": {
-      "version": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.34.tgz",
-      "integrity": "sha1-A5Y3BFh3J3QEHl2771euAoLuYcI=",
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
       "dependencies": {
-        "globals": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
-        "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
-    "babel-plugin-constant-folding": {
-      "version": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
-      "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4=",
-      "dev": true
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
-    "babel-plugin-dead-code-elimination": {
-      "version": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
-      "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U=",
-      "dev": true
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.6",
+        "regenerator-runtime": "0.11.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.6",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+          "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
+          "dev": true
+        }
+      }
     },
-    "babel-plugin-eval": {
-      "version": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
-      "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo=",
-      "dev": true
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
     },
-    "babel-plugin-inline-environment-variables": {
-      "version": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
-      "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4=",
-      "dev": true
-    },
-    "babel-plugin-jscript": {
-      "version": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
-      "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w=",
-      "dev": true
-    },
-    "babel-plugin-member-expression-literals": {
-      "version": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
-      "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM=",
-      "dev": true
-    },
-    "babel-plugin-property-literals": {
-      "version": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
-      "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY=",
-      "dev": true
-    },
-    "babel-plugin-proto-to-assign": {
-      "version": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
-      "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
-      "dev": true
-    },
-    "babel-plugin-react-constant-elements": {
-      "version": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
-      "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o=",
-      "dev": true
-    },
-    "babel-plugin-react-display-name": {
-      "version": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
-      "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw=",
-      "dev": true
-    },
-    "babel-plugin-remove-console": {
-      "version": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
-      "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c=",
-      "dev": true
-    },
-    "babel-plugin-remove-debugger": {
-      "version": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
-      "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc=",
-      "dev": true
-    },
-    "babel-plugin-runtime": {
-      "version": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
-      "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8=",
-      "dev": true
-    },
-    "babel-plugin-undeclared-variables-check": {
-      "version": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-      "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
-      "dev": true
-    },
-    "babel-plugin-undefined-to-void": {
-      "version": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
-      "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E=",
-      "dev": true
-    },
-    "babylon": {
-      "version": "https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz",
-      "integrity": "sha1-VJ9XP0XDvF51sqV2OQJ9LXJO2qo=",
-      "dev": true
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
+      },
+      "dependencies": {
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
+        }
+      }
     },
     "balanced-match": {
       "version": "0.4.2",
@@ -223,13 +255,20 @@
       "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
       "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+      }
     },
     "benchmark": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
       "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
       "dev": true,
+      "requires": {
+        "lodash": "4.17.4",
+        "platform": "1.3.4"
+      },
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
@@ -248,32 +287,33 @@
     "bl": {
       "version": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-      "dev": true
-    },
-    "bluebird": {
-      "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-      "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+      }
     },
     "boom": {
       "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      }
     },
     "brace-expansion": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
       "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2",
+        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+      }
     },
-    "breakable": {
-      "version": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
-      "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME=",
-      "dev": true
-    },
-    "camelcase": {
-      "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "dev": true
     },
     "caseless": {
@@ -281,52 +321,27 @@
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
       "dev": true
     },
-    "center-align": {
-      "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-      "integrity": "sha1-dPqFQPwZsmqubtx+AxzWmT1JW6A=",
-      "dev": true
-    },
     "chalk": {
       "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
       "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
+        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+      }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clean-yaml-object": {
       "version": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
       "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
-      "dev": true
-    },
-    "cli-cursor": {
-      "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
-    },
-    "cli-width": {
-      "version": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz",
-      "integrity": "sha1-32LR4amA72DRJW82TU8mlVlNfss=",
-      "dev": true
-    },
-    "cliui": {
-      "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        }
-      }
-    },
-    "clone": {
-      "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
-      "dev": true
-    },
-    "code-point-at": {
-      "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-      "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
       "dev": true
     },
     "color-support": {
@@ -337,49 +352,22 @@
     "combined-stream": {
       "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+      }
     },
     "commander": {
       "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
-    },
-    "commoner": {
-      "version": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
-      "integrity": "sha1-mPMzPdOtOZWWuy04Sng7tyE9aPg=",
       "dev": true,
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
-        }
+      "requires": {
+        "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
       }
     },
     "concat-map": {
       "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "concat-stream": {
-      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-      "integrity": "sha1-87gKz54fSOOHXAaItBtsMWAu6hw=",
-      "dev": true
-    },
-    "config-chain": {
-      "version": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
-      "integrity": "sha1-Oax9TcqE+q2SYSTFTP8lpTqov24=",
-      "dev": true
-    },
-    "convert-source-map": {
-      "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz",
-      "integrity": "sha1-gmY3iDEHOQf6OE8LKuyrC6BYZpM=",
-      "dev": true
-    },
-    "core-js": {
-      "version": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
-      "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU=",
       "dev": true
     },
     "core-util-is": {
@@ -392,12 +380,22 @@
       "version": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.15.tgz",
       "integrity": "sha1-N9NHQ2nWbBTzP6c6nSXO5uCZ/KA=",
       "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+        "log-driver": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.75.0.tgz"
+      },
       "dependencies": {
         "argparse": {
           "version": "1.0.9",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+          }
         },
         "esprima": {
           "version": "2.7.3",
@@ -409,29 +407,38 @@
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
           "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
+          }
         }
       }
     },
     "cross-spawn": {
       "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+        "which": "1.2.14"
+      }
     },
     "cryptiles": {
       "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
-    },
-    "d": {
-      "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+      }
     },
     "dashdash": {
       "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -444,79 +451,14 @@
     "debug": {
       "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-      "dev": true
-    },
-    "debug-log": {
-      "version": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.0.tgz",
-      "integrity": "sha1-6lIIAbS3gYG5jJSZRSWAw0xPC/4=",
-      "dev": true
-    },
-    "decamelize": {
-      "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
-      "integrity": "sha1-iHFHmmwEh/VlPUipkvHQOBym8DE=",
-      "dev": true
-    },
-    "deep-is": {
-      "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+      }
     },
     "deeper": {
       "version": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz",
       "integrity": "sha1-vFZOX3MXT98gHgiwADDooU2nQ2g=",
-      "dev": true
-    },
-    "defaults": {
-      "version": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true
-    },
-    "defined": {
-      "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true
-    },
-    "defs": {
-      "version": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-      "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
-      "dev": true,
-      "dependencies": {
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.27.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-          "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
-          "dev": true
-        }
-      }
-    },
-    "deglob": {
-      "version": "https://registry.npmjs.org/deglob/-/deglob-1.0.2.tgz",
-      "integrity": "sha1-p1r90sBy/e4MrxpERk42Or+N9f0=",
-      "dev": true,
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
-        }
-      }
-    },
-    "del": {
-      "version": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
-      "integrity": "sha1-mlDwS/NzJeKDtPROmFM2wlJFa9U=",
       "dev": true
     },
     "delayed-stream": {
@@ -524,239 +466,100 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
-    "detect-indent": {
-      "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-      "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-      "dev": true
-    },
-    "detective": {
-      "version": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
-      "integrity": "sha1-n7Bt0e6PDqTbzGB82jnZzh1Pcm8=",
-      "dev": true
-    },
-    "dezalgo": {
-      "version": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "dev": true
-    },
     "diff": {
       "version": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
     },
-    "disparity": {
-      "version": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
-      "integrity": "sha1-V92stHMkrl9Y0swNqIbbTOnutxg=",
-      "dev": true
-    },
-    "doctrine": {
-      "version": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
-      "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
-      "dev": true,
-      "dependencies": {
-        "esutils": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
-          "dev": true
-        }
-      }
-    },
     "ecc-jsbn": {
       "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+      }
     },
-    "es5-ext": {
-      "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
-      "integrity": "sha1-gYTD5wWoIJSMLb4EOEk3mx29DEU=",
-      "dev": true
-    },
-    "es6-iterator": {
-      "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-      "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-      "dev": true
-    },
-    "es6-map": {
-      "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
-      "integrity": "sha1-/ljGZUxqzVTkOXzbcjedWbatWJQ=",
-      "dev": true
-    },
-    "es6-set": {
-      "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.3.tgz",
-      "integrity": "sha1-djMUXHA7zjfxD6lB5wyWmRAB7FA=",
-      "dev": true
-    },
-    "es6-symbol": {
-      "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-      "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk=",
-      "dev": true
-    },
-    "es6-weak-map": {
-      "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-      "integrity": "sha1-DSu9iCfrX7S6j5f7/qUNQ9sh6oE=",
-      "dev": true
+    "editorconfig": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
+      "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "commander": "2.15.1",
+        "lru-cache": "3.2.0",
+        "semver": "5.5.0",
+        "sigmund": "1.0.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+          "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
     },
     "escape-string-regexp": {
       "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
       "integrity": "sha1-uF5nm0b3LQP7voo79yWdU1whti8=",
       "dev": true
     },
-    "escope": {
-      "version": "https://registry.npmjs.org/escope/-/escope-3.3.0.tgz",
-      "integrity": "sha1-YgHJcoXCwTZDr+RFO1jeZEgaoaQ=",
-      "dev": true
-    },
-    "esformatter": {
-      "version": "https://registry.npmjs.org/esformatter/-/esformatter-0.8.1.tgz",
-      "integrity": "sha1-fivWnVscMeP9rjuFkT1lv9WJhrw=",
+    "esformatter-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esformatter-parser/-/esformatter-parser-1.0.0.tgz",
+      "integrity": "sha1-CFQHLQSHU57TnK442KVDLBfsEdM=",
       "dev": true,
+      "requires": {
+        "acorn-to-esprima": "2.0.8",
+        "babel-traverse": "6.26.0",
+        "babylon": "6.18.0",
+        "rocambole": "0.7.0"
+      },
       "dependencies": {
-        "debug": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-          "dev": true
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
-          "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
-          "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0=",
-          "dev": true
-        }
-      }
-    },
-    "esformatter-eol-last": {
-      "version": "https://registry.npmjs.org/esformatter-eol-last/-/esformatter-eol-last-1.0.0.tgz",
-      "integrity": "sha1-RaeP9GIrHUnkT1a0mQV2amMpDAc=",
-      "dev": true
-    },
-    "esformatter-ignore": {
-      "version": "https://registry.npmjs.org/esformatter-ignore/-/esformatter-ignore-0.1.3.tgz",
-      "integrity": "sha1-BNO4db+knd4ATMWN9va7w8BWfx4=",
-      "dev": true
-    },
-    "esformatter-jsx": {
-      "version": "https://registry.npmjs.org/esformatter-jsx/-/esformatter-jsx-2.3.11.tgz",
-      "integrity": "sha1-QRxE7TJHVK+VquXe2FbVp+78td8=",
-      "dev": true
-    },
-    "esformatter-literal-notation": {
-      "version": "https://registry.npmjs.org/esformatter-literal-notation/-/esformatter-literal-notation-1.0.1.tgz",
-      "integrity": "sha1-cQ57QgF1/j9+WvrVu60ykQOELi8=",
-      "dev": true,
-      "dependencies": {
-        "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         },
         "rocambole": {
-          "version": "0.3.6",
-          "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.3.6.tgz",
-          "integrity": "sha1-Teu/WUMUS8e2AG2Vvo+swLdDUqc=",
-          "dev": true
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
+          "integrity": "sha1-9seVBVF9xCtvuECEK4uVOw+WhYU=",
+          "dev": true,
+          "requires": {
+            "esprima": "2.7.3"
+          }
         }
       }
     },
-    "esformatter-quotes": {
-      "version": "https://registry.npmjs.org/esformatter-quotes/-/esformatter-quotes-1.0.3.tgz",
-      "integrity": "sha1-B0Cv5G30B8jj3heaqZKNs9hZqiA=",
-      "dev": true
-    },
-    "esformatter-semicolon-first": {
-      "version": "https://registry.npmjs.org/esformatter-semicolon-first/-/esformatter-semicolon-first-1.1.0.tgz",
-      "integrity": "sha1-63UwrHX20ANxEFZeVfGzAycuDpM=",
-      "dev": true
-    },
-    "esformatter-spaced-lined-comment": {
-      "version": "https://registry.npmjs.org/esformatter-spaced-lined-comment/-/esformatter-spaced-lined-comment-2.0.1.tgz",
-      "integrity": "sha1-3F80B/k8KV4eVkRr00RWDaXm3Kw=",
-      "dev": true
-    },
-    "eslint": {
-      "version": "https://registry.npmjs.org/eslint/-/eslint-1.9.0.tgz",
-      "integrity": "sha1-p1qvB+KGUHcu0OcNqizggwebZRQ=",
-      "dev": true,
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
-        }
-      }
-    },
-    "eslint-config-standard": {
-      "version": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-4.4.0.tgz",
-      "integrity": "sha1-wSl0nhmZ4M+GEHeyddnFHc2XzXU=",
-      "dev": true
-    },
-    "eslint-config-standard-react": {
-      "version": "https://registry.npmjs.org/eslint-config-standard-react/-/eslint-config-standard-react-1.2.1.tgz",
-      "integrity": "sha1-7QRf2yKzoP4LsL1EnPO/vq7etbM=",
-      "dev": true
-    },
-    "eslint-plugin-react": {
-      "version": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.12.0.tgz",
-      "integrity": "sha1-c/42psSKghEdDLOa/N+aIbZQhS4=",
-      "dev": true
-    },
-    "eslint-plugin-standard": {
-      "version": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-1.3.1.tgz",
-      "integrity": "sha1-YOllUT02YDnp/7LRx1i5WlpSNoM=",
-      "dev": true
-    },
-    "espree": {
-      "version": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
-      "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
-      "dev": true
-    },
-    "esrecurse": {
-      "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
-      "integrity": "sha1-j+uWNpnU0bLWWlds1LEpZnKg8Ok=",
-      "dev": true,
-      "dependencies": {
-        "estraverse": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
-          "integrity": "sha1-FeKKRGuLgrxwDMyLlseK9NoNbLo=",
-          "dev": true
-        }
-      }
-    },
-    "estraverse": {
-      "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-      "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-      "dev": true
-    },
-    "estraverse-fb": {
-      "version": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
-      "integrity": "sha1-Fg51qA5gWwjOiUvM4v4+Qpq/kr8=",
-      "dev": true
-    },
-    "esutils": {
-      "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
-    },
-    "event-emitter": {
-      "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
-      "integrity": "sha1-jWPd+0z+H647MsomXExyAiIIC7U=",
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
     "events-to-array": {
@@ -764,49 +567,9 @@
       "integrity": "sha1-s0hEZVNP5P9m+90ag7d3cTukBKo=",
       "dev": true
     },
-    "exit-hook": {
-      "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-      "dev": true
-    },
-    "extend": {
-      "version": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
-      "integrity": "sha1-HugBBonnOV/5RIJByYZSvHWagmA=",
-      "dev": true
-    },
     "extsprintf": {
       "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-      "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-      "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
-      "dev": true
-    },
-    "figures": {
-      "version": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
-      "integrity": "sha1-649WOQ2+MIEESlwqnZCJB1pIQy8=",
-      "dev": true
-    },
-    "file-entry-cache": {
-      "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
-      "integrity": "sha1-mlhgcsaTZafvfscqfCuQRt4JHpw=",
-      "dev": true
-    },
-    "find-root": {
-      "version": "https://registry.npmjs.org/find-root/-/find-root-0.1.1.tgz",
-      "integrity": "sha1-9jbUbz518IXzKJ63x3keUDmjd8o=",
-      "dev": true
-    },
-    "flat-cache": {
-      "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
-      "integrity": "sha1-c9bfSihQIWCgXgWVRKau6uiwBHo=",
-      "dev": true
-    },
-    "foreach": {
-      "version": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "foreground-child": {
@@ -814,6 +577,10 @@
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
+      "requires": {
+        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+        "signal-exit": "3.0.2"
+      },
       "dependencies": {
         "signal-exit": {
           "version": "3.0.2",
@@ -831,22 +598,17 @@
     "form-data": {
       "version": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
       "integrity": "sha1-bwrrrcxdoWwT4ezBETfYX5uIOyU=",
-      "dev": true
-    },
-    "fresh-falafel": {
-      "version": "https://registry.npmjs.org/fresh-falafel/-/fresh-falafel-1.2.0.tgz",
-      "integrity": "sha1-WWbe6V+zXSopsS0vJRaLFyJeS2w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
+      }
     },
     "fs-exists-cached": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
       "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=",
-      "dev": true
-    },
-    "fs-readdir-recursive": {
-      "version": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
-      "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk=",
       "dev": true
     },
     "fs.realpath": {
@@ -868,17 +630,18 @@
     "generate-object-property": {
       "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+      }
     },
     "getpass": {
       "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -892,51 +655,43 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true
-    },
-    "globals": {
-      "version": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
-      "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs=",
-      "dev": true
-    },
-    "globby": {
-      "version": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
-      "integrity": "sha1-Nv8GxancHbwgH3AAdJkogoV+mBc=",
       "dev": true,
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true
-        }
+      "requires": {
+        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
       }
-    },
-    "graceful-fs": {
-      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-      "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc=",
-      "dev": true
     },
     "graceful-readlink": {
       "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
-    "handlebars": {
-      "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
-      "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
-      "dev": true
-    },
     "har-validator": {
       "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+        "is-my-json-valid": "2.16.0",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+      },
       "dependencies": {
         "is-my-json-valid": {
           "version": "2.16.0",
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
           "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+            "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "jsonpointer": "4.0.1",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
         },
         "jsonpointer": {
           "version": "4.0.1",
@@ -949,50 +704,45 @@
     "has-ansi": {
       "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+      }
     },
     "hawk": {
       "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+      }
     },
     "hoek": {
       "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
-    "home-or-tmp": {
-      "version": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-      "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-      "dev": true,
-      "dependencies": {
-        "user-home": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-          "dev": true
-        }
-      }
-    },
     "http-signature": {
       "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
-    },
-    "iconv-lite": {
-      "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-      "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
-      "dev": true
-    },
-    "ignore": {
-      "version": "https://registry.npmjs.org/ignore/-/ignore-2.2.19.tgz",
-      "integrity": "sha1-TIRaYfflC0pBD2FWqqOLatleDI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+        "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+        "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz"
+      }
     },
     "inflight": {
       "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
       "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+      }
     },
     "inherit": {
       "version": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz",
@@ -1004,15 +754,14 @@
       "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
       "dev": true
     },
-    "ini": {
-      "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-      "dev": true
-    },
-    "inquirer": {
-      "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.0.tgz",
-      "integrity": "sha1-dEi/qSQJKvMR1HFzu6uZDK4rsCc=",
-      "dev": true
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -1020,54 +769,15 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
-    "is-buffer": {
-      "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-      "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A=",
-      "dev": true
-    },
-    "is-finite": {
-      "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-      "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
-      "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true
-    },
-    "is-integer": {
-      "version": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
-      "integrity": "sha1-UnOBn62ogNEj4awAqTjnFy3Y2V4=",
-      "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
-      "integrity": "sha1-WjnR12stu4MUC70Vex1e5L3IWtY=",
-      "dev": true
-    },
-    "is-path-cwd": {
-      "version": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
-    },
-    "is-path-inside": {
-      "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
       "dev": true
     },
     "is-property": {
       "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
-    },
-    "is-resolvable": {
-      "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true
     },
     "is-typedarray": {
@@ -1094,22 +804,20 @@
       "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
       "dev": true,
-      "optional": true
-    },
-    "js-beautify": {
-      "version": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.10.tgz",
-      "integrity": "sha1-TZU3FwJpk0SlFsomv1nwonu3Vxk=",
-      "dev": true
-    },
-    "js-tokens": {
-      "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-      "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
-      "dev": true
+      "optional": true,
+      "requires": {
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+      }
     },
     "js-yaml": {
       "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
       "integrity": "sha1-a+GyP2JJ9T0pM3D9TRqqY84bTrA=",
       "dev": true,
+      "requires": {
+        "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
+        "esprima": "2.7.3",
+        "inherit": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -1125,19 +833,9 @@
       "dev": true,
       "optional": true
     },
-    "jsesc": {
-      "version": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-      "dev": true
-    },
     "json-schema": {
       "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
-    },
-    "json-stable-stringify": {
-      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.0.tgz",
-      "integrity": "sha1-XiaFnPSZaM+kmVM0E0Q1eO4E0lE=",
       "dev": true
     },
     "json-stringify-safe": {
@@ -1145,65 +843,28 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json5": {
-      "version": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-      "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-      "dev": true
-    },
-    "jsonify": {
-      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
-    "jsonpointer": {
-      "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-      "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
-      "dev": true
-    },
     "jsprim": {
       "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
       "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
-      "dev": true
-    },
-    "kind-of": {
-      "version": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-      "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-      "dev": true
-    },
-    "lazy-cache": {
-      "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-      "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+        "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+        "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+      }
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
     },
     "lcov-parse": {
       "version": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-      "dev": true
-    },
-    "left-pad": {
-      "version": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
-      "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE=",
-      "dev": true
-    },
-    "leven": {
-      "version": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
-      "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM=",
-      "dev": true
-    },
-    "levn": {
-      "version": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-      "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
-      "dev": true
-    },
-    "line-numbers": {
-      "version": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-      "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
       "dev": true
     },
     "lodash": {
@@ -1211,165 +872,36 @@
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
       "dev": true
     },
-    "lodash._arraycopy": {
-      "version": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
-      "dev": true
-    },
-    "lodash._arrayeach": {
-      "version": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
-      "dev": true
-    },
-    "lodash._arraymap": {
-      "version": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
-      "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
-      "dev": true
-    },
-    "lodash._baseassign": {
-      "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
-    },
-    "lodash._baseclone": {
-      "version": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
-      "dev": true
-    },
-    "lodash._basecopy": {
-      "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basedifference": {
-      "version": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
-      "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
-      "dev": true
-    },
-    "lodash._baseflatten": {
-      "version": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
-      "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
-      "dev": true
-    },
-    "lodash._basefor": {
-      "version": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
-      "integrity": "sha1-Okzs5bcDHq54pEHFQWuQh47u5aE=",
-      "dev": true
-    },
-    "lodash._baseindexof": {
-      "version": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-      "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
-      "dev": true
-    },
-    "lodash._bindcallback": {
-      "version": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-      "dev": true
-    },
-    "lodash._cacheindexof": {
-      "version": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-      "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
-      "dev": true
-    },
-    "lodash._createassigner": {
-      "version": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "dev": true
-    },
-    "lodash._createcache": {
-      "version": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash._pickbyarray": {
-      "version": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
-      "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
-      "dev": true
-    },
-    "lodash._pickbycallback": {
-      "version": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
-      "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
-      "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
-      "dev": true
-    },
-    "lodash.isarguments": {
-      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-      "integrity": "sha1-67uITEjSc2akTqb+5X7XtaMqgeA=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.isplainobject": {
-      "version": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-      "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
-      "dev": true
-    },
-    "lodash.istypedarray": {
-      "version": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz",
-      "integrity": "sha1-k5exE8FfQk8yCvBsqlnMSV4gk84=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
-    },
-    "lodash.keysin": {
-      "version": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
-      "dev": true
-    },
-    "lodash.merge": {
-      "version": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
-      "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
-      "dev": true
-    },
-    "lodash.omit": {
-      "version": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
-      "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
-      "dev": true
-    },
-    "lodash.restparam": {
-      "version": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-      "dev": true
-    },
-    "lodash.toplainobject": {
-      "version": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
-      "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
-      "dev": true
-    },
     "log-driver": {
       "version": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
       "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
       "dev": true
     },
-    "longest": {
-      "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        }
+      }
     },
     "lru-cache": {
       "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
       "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
       "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      },
       "dependencies": {
         "pseudomap": {
           "version": "1.0.2",
@@ -1393,13 +925,19 @@
     "mime-types": {
       "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
       "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.7"
+      },
       "dependencies": {
         "balanced-match": {
           "version": "0.4.2",
@@ -1411,7 +949,11 @@
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
           "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+          }
         }
       }
     },
@@ -1420,37 +962,15 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
-    "mkdirp": {
-      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
-      }
-    },
-    "mout": {
-      "version": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-      "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k=",
-      "dev": true
-    },
     "ms": {
       "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
       "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
       "dev": true
     },
-    "multiline": {
-      "version": "https://registry.npmjs.org/multiline/-/multiline-1.0.2.tgz",
-      "integrity": "sha1-abHyX/B00oKJBPJE3dBrfZbvbJM=",
-      "dev": true
-    },
-    "mute-stream": {
-      "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "node-uuid": {
@@ -1458,51 +978,47 @@
       "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
       "dev": true
     },
-    "nopt": {
-      "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
-    },
-    "npm-path": {
-      "version": "https://registry.npmjs.org/npm-path/-/npm-path-1.0.2.tgz",
-      "integrity": "sha1-5/bs9eUfjvlyy6o7LCnOvC1pqHA=",
-      "dev": true
-    },
-    "npm-run": {
-      "version": "https://registry.npmjs.org/npm-run/-/npm-run-1.1.1.tgz",
-      "integrity": "sha1-xDEkUfOCt67npIWOYCg6vz26yOw=",
-      "dev": true
-    },
-    "number-is-nan": {
-      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-      "dev": true
+    "npm-which": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-2.0.0.tgz",
+      "integrity": "sha1-DEaYIWC3gwk2YdHQG9RJbS/qu6w=",
+      "dev": true,
+      "requires": {
+        "commander": "2.15.1",
+        "npm-path": "1.1.0",
+        "which": "1.2.14"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
+        "npm-path": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-1.1.0.tgz",
+          "integrity": "sha1-BHSuAEGcMn1UcBt88s0F3Ii+EUA=",
+          "dev": true,
+          "requires": {
+            "which": "1.2.14"
+          }
+        }
+      }
     },
     "oauth-sign": {
       "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
-    "object-assign": {
-      "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-      "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0=",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz",
-      "integrity": "sha1-yrsSAtmnrym1Dt+s6AlLtG2l6iE=",
-      "dev": true
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
-    },
-    "onetime": {
-      "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+      }
     },
     "only-shallow": {
       "version": "https://registry.npmjs.org/only-shallow/-/only-shallow-1.2.0.tgz",
@@ -1514,24 +1030,6 @@
       "integrity": "sha1-syWCCABCr4aAw4mkmRdbTFT/9SM=",
       "dev": true
     },
-    "optimist": {
-      "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        }
-      }
-    },
-    "optionator": {
-      "version": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz",
-      "integrity": "sha1-tj7Lvw4xX61LyYJ7Rdx7pFKE/LY=",
-      "dev": true
-    },
     "os-homedir": {
       "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
       "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
@@ -1541,16 +1039,15 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lcid": "1.0.0"
+      }
     },
-    "os-tmpdir": {
-      "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-      "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
-      "dev": true
-    },
-    "output-file-sync": {
-      "version": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
-      "integrity": "sha1-pGU5l8LfY8mBH38dehIIQE7TLp4=",
+    "os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
       "dev": true
     },
     "own-or": {
@@ -1565,24 +1062,15 @@
       "integrity": "sha1-nvkg/IHi5jz1nUEQElg2jPT8pPs=",
       "dev": true
     },
-    "path-exists": {
-      "version": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-      "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-      "dev": true
-    },
     "path-is-absolute": {
       "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
       "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
       "dev": true
     },
-    "path-is-inside": {
-      "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
-      "integrity": "sha1-mNjx0DC/BL167uShulSF1AMY/Yk=",
-      "dev": true
-    },
-    "pify": {
-      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "pinkie": {
@@ -1593,12 +1081,10 @@
     "pinkie-promise": {
       "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
       "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
-      "dev": true
-    },
-    "pkg-config": {
-      "version": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.0.tgz",
-      "integrity": "sha1-H5aEsSwP1bzvOyvXUmVDO5e3TF0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+      }
     },
     "platform": {
       "version": "1.3.4",
@@ -1606,29 +1092,9 @@
       "integrity": "sha1-bw+xftqqSPIUQrOpdcBjEw8cPr0=",
       "dev": true
     },
-    "prelude-ls": {
-      "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
-    "private": {
-      "version": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-      "integrity": "sha1-VcapdtD5uvuZJIUTUP5HubX7t8E=",
-      "dev": true
-    },
     "process-nextick-args": {
       "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
       "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU=",
-      "dev": true
-    },
-    "proto-list": {
-      "version": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
-    },
-    "protochain": {
-      "version": "https://registry.npmjs.org/protochain/-/protochain-1.0.3.tgz",
-      "integrity": "sha1-2gwWDWdNasTQcneLpa4+JLThR1w=",
       "dev": true
     },
     "pseudomap": {
@@ -1641,105 +1107,57 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
-    "q": {
-      "version": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
-      "dev": true
-    },
     "qs": {
       "version": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
       "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
       "dev": true
     },
-    "read-json-sync": {
-      "version": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz",
-      "integrity": "sha1-Q8ZproZKrjCN+7snIaZ+KV7I//Y=",
-      "dev": true
-    },
     "readable-stream": {
       "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
       "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
-      "dev": true
-    },
-    "readline2": {
-      "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true
-    },
-    "recast": {
-      "version": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-      "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
       "dev": true,
-      "dependencies": {
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-          "dev": true
-        }
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
       }
     },
-    "regenerate": {
-      "version": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
-      "integrity": "sha1-njC6aKa9lqw9y6YqsJ1V1LL8vgQ=",
-      "dev": true
-    },
-    "regenerator": {
-      "version": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-      "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
-      "dev": true,
-      "dependencies": {
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
-          "dev": true
-        }
-      }
-    },
-    "regexpu": {
-      "version": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-      "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
-      "dev": true,
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        }
-      }
-    },
-    "regjsgen": {
-      "version": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true
-    },
-    "repeat-string": {
-      "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-      "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo=",
-      "dev": true
-    },
-    "repeating": {
-      "version": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-      "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "request": {
       "version": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
       "integrity": "sha1-0rgmiihtoT6qXQGt9dGMyQ9lfZM=",
       "dev": true,
+      "requires": {
+        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+        "bl": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+        "extend": "3.0.1",
+        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+        "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+      },
       "dependencies": {
         "extend": {
           "version": "3.0.1",
@@ -1749,79 +1167,14 @@
         }
       }
     },
-    "resolve": {
-      "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
-      "integrity": "sha1-00kq0FTKgA9b76YS5hvqwe7Jj48=",
-      "dev": true
-    },
-    "restore-cursor": {
-      "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
-    },
-    "right-align": {
-      "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true
-    },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
-    },
-    "rocambole": {
-      "version": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
-      "integrity": "sha1-9seVBVF9xCtvuECEK4uVOw+WhYU=",
       "dev": true,
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        }
+      "requires": {
+        "glob": "7.1.2"
       }
-    },
-    "rocambole-indent": {
-      "version": "https://registry.npmjs.org/rocambole-indent/-/rocambole-indent-2.0.4.tgz",
-      "integrity": "sha1-oYokl3ygQAuGHapGMehh3LUtCFw=",
-      "dev": true
-    },
-    "rocambole-linebreak": {
-      "version": "https://registry.npmjs.org/rocambole-linebreak/-/rocambole-linebreak-1.0.1.tgz",
-      "integrity": "sha1-Y/YrEQwRCOcYRGD50rrDG5TFw8A=",
-      "dev": true
-    },
-    "rocambole-node": {
-      "version": "https://registry.npmjs.org/rocambole-node/-/rocambole-node-1.0.0.tgz",
-      "integrity": "sha1-21tJ3nQHsAgN1RSHLyjjk9D3/z8=",
-      "dev": true
-    },
-    "rocambole-token": {
-      "version": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz",
-      "integrity": "sha1-x4XfdCjcPLJ614lwR71SOMwHDTU=",
-      "dev": true
-    },
-    "rocambole-whitespace": {
-      "version": "https://registry.npmjs.org/rocambole-whitespace/-/rocambole-whitespace-1.0.0.tgz",
-      "integrity": "sha1-YzMJSSVrKZQfWbGQRZ+ZnGsdO/k=",
-      "dev": true
-    },
-    "run-async": {
-      "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
-    },
-    "run-parallel": {
-      "version": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.4.tgz",
-      "integrity": "sha1-tPwFq2MqXnZ73WkbSqvnuKzJq7I=",
-      "dev": true
-    },
-    "rx-lite": {
-      "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-      "dev": true
     },
     "safe-buffer": {
       "version": "5.0.1",
@@ -1829,60 +1182,106 @@
       "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
       "dev": true
     },
-    "semver": {
-      "version": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "serializerr": {
-      "version": "https://registry.npmjs.org/serializerr/-/serializerr-1.0.2.tgz",
-      "integrity": "sha1-rIs9jK2o/GFk3yBWj8YYKVJzG5o=",
-      "dev": true
-    },
-    "shebang-regex": {
-      "version": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "shelljs": {
-      "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
-      "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
-      "dev": true
-    },
-    "simple-fmt": {
-      "version": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
-      "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms=",
-      "dev": true
-    },
-    "simple-is": {
-      "version": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
-      "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
-      "dev": true
-    },
-    "slash": {
-      "version": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "sntp": {
       "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
-    },
-    "source-map": {
-      "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-      "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
       "dev": true,
+      "requires": {
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      }
+    },
+    "spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "os-shim": "0.1.3"
+      },
       "dependencies": {
-        "source-map": {
-          "version": "0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-          "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+          "dev": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         }
       }
@@ -1896,6 +1295,17 @@
       "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
       "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
       "dev": true,
+      "requires": {
+        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+        "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+        "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+        "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+        "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1905,49 +1315,2667 @@
         }
       }
     },
-    "stable": {
-      "version": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
-      "integrity": "sha1-CCMvYMcy6YkHhLW+0HNPizKoh7k=",
-      "dev": true
-    },
     "standard": {
-      "version": "https://registry.npmjs.org/standard/-/standard-5.4.1.tgz",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-5.4.1.tgz",
       "integrity": "sha1-LwE5ErJ5Tdswu6qJ3BP7OpkMxys=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eslint-config-standard": "4.4.0",
+        "eslint-config-standard-react": "1.2.1",
+        "eslint-plugin-react": "3.16.1",
+        "eslint-plugin-standard": "1.3.3",
+        "standard-engine": "2.2.5",
+        "standard-format": "1.6.10"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "dev": true
+        },
+        "acorn": {
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+          "dev": true
+        },
+        "align-text": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "alter": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+          "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
+          "dev": true,
+          "requires": {
+            "stable": "0.1.8"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+          "dev": true
+        },
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "1.0.3"
+          }
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+          "dev": true,
+          "requires": {
+            "array-uniq": "1.0.3"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+          "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        },
+        "asap": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+          "dev": true
+        },
+        "ast-traverse": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+          "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY=",
+          "dev": true
+        },
+        "ast-types": {
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+          "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "babel-core": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
+          "dev": true,
+          "requires": {
+            "babel-plugin-constant-folding": "1.0.1",
+            "babel-plugin-dead-code-elimination": "1.0.2",
+            "babel-plugin-eval": "1.0.1",
+            "babel-plugin-inline-environment-variables": "1.0.1",
+            "babel-plugin-jscript": "1.0.4",
+            "babel-plugin-member-expression-literals": "1.0.1",
+            "babel-plugin-property-literals": "1.0.1",
+            "babel-plugin-proto-to-assign": "1.0.4",
+            "babel-plugin-react-constant-elements": "1.0.3",
+            "babel-plugin-react-display-name": "1.0.3",
+            "babel-plugin-remove-console": "1.0.1",
+            "babel-plugin-remove-debugger": "1.0.1",
+            "babel-plugin-runtime": "1.0.7",
+            "babel-plugin-undeclared-variables-check": "1.0.2",
+            "babel-plugin-undefined-to-void": "1.1.6",
+            "babylon": "5.8.38",
+            "bluebird": "2.11.0",
+            "chalk": "1.1.3",
+            "convert-source-map": "1.5.1",
+            "core-js": "1.2.7",
+            "debug": "2.6.9",
+            "detect-indent": "3.0.1",
+            "esutils": "2.0.2",
+            "fs-readdir-recursive": "0.1.2",
+            "globals": "6.4.1",
+            "home-or-tmp": "1.0.0",
+            "is-integer": "1.0.7",
+            "js-tokens": "1.0.1",
+            "json5": "0.4.0",
+            "lodash": "3.10.1",
+            "minimatch": "2.0.10",
+            "output-file-sync": "1.1.2",
+            "path-exists": "1.0.0",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "regenerator": "0.8.40",
+            "regexpu": "1.3.0",
+            "repeating": "1.1.3",
+            "resolve": "1.7.1",
+            "shebang-regex": "1.0.0",
+            "slash": "1.0.0",
+            "source-map": "0.5.7",
+            "source-map-support": "0.2.10",
+            "to-fast-properties": "1.0.3",
+            "trim-right": "1.0.1",
+            "try-resolve": "1.0.1"
+          },
+          "dependencies": {
+            "globals": {
+              "version": "6.4.1",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+              "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.7"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "babel-plugin-constant-folding": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
+          "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4=",
+          "dev": true
+        },
+        "babel-plugin-dead-code-elimination": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
+          "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U=",
+          "dev": true
+        },
+        "babel-plugin-eval": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
+          "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo=",
+          "dev": true
+        },
+        "babel-plugin-inline-environment-variables": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
+          "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4=",
+          "dev": true
+        },
+        "babel-plugin-jscript": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
+          "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w=",
+          "dev": true
+        },
+        "babel-plugin-member-expression-literals": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
+          "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM=",
+          "dev": true
+        },
+        "babel-plugin-property-literals": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
+          "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY=",
+          "dev": true
+        },
+        "babel-plugin-proto-to-assign": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
+          "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
+          "dev": true,
+          "requires": {
+            "lodash": "3.10.1"
+          }
+        },
+        "babel-plugin-react-constant-elements": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
+          "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o=",
+          "dev": true
+        },
+        "babel-plugin-react-display-name": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
+          "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw=",
+          "dev": true
+        },
+        "babel-plugin-remove-console": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
+          "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c=",
+          "dev": true
+        },
+        "babel-plugin-remove-debugger": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
+          "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc=",
+          "dev": true
+        },
+        "babel-plugin-runtime": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
+          "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8=",
+          "dev": true
+        },
+        "babel-plugin-undeclared-variables-check": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+          "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
+          "dev": true,
+          "requires": {
+            "leven": "1.0.2"
+          }
+        },
+        "babel-plugin-undefined-to-void": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
+          "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E=",
+          "dev": true
+        },
+        "babylon": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+          "dev": true
+        },
+        "breakable": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+          "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+          "dev": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "cli-width": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+          "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+              "dev": true
+            }
+          }
+        },
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+          "dev": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
+        "commoner": {
+          "version": "0.10.8",
+          "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+          "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+          "dev": true,
+          "requires": {
+            "commander": "2.15.1",
+            "detective": "4.7.1",
+            "glob": "5.0.15",
+            "graceful-fs": "4.1.11",
+            "iconv-lite": "0.4.22",
+            "mkdirp": "0.5.1",
+            "private": "0.1.8",
+            "q": "1.5.1",
+            "recast": "0.11.23"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+              "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+              "dev": true
+            },
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
+              "requires": {
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "recast": {
+              "version": "0.11.23",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+              "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+              "dev": true,
+              "requires": {
+                "ast-types": "0.9.6",
+                "esprima": "3.1.3",
+                "private": "0.1.8",
+                "source-map": "0.5.7"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
+          }
+        },
+        "config-chain": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+          "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+          "dev": true,
+          "requires": {
+            "ini": "1.3.5",
+            "proto-list": "1.2.4"
+          }
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+          "dev": true
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "d": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+          "dev": true,
+          "requires": {
+            "es5-ext": "0.10.42"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+          "dev": true
+        },
+        "defaults": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+          "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+          "dev": true,
+          "requires": {
+            "clone": "1.0.4"
+          }
+        },
+        "defined": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+          "dev": true
+        },
+        "defs": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+          "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
+          "dev": true,
+          "requires": {
+            "alter": "0.2.0",
+            "ast-traverse": "0.1.1",
+            "breakable": "1.0.0",
+            "esprima-fb": "15001.1001.0-dev-harmony-fb",
+            "simple-fmt": "0.1.0",
+            "simple-is": "0.2.0",
+            "stringmap": "0.2.2",
+            "stringset": "0.2.1",
+            "tryor": "0.1.2",
+            "yargs": "3.27.0"
+          },
+          "dependencies": {
+            "esprima-fb": {
+              "version": "15001.1001.0-dev-harmony-fb",
+              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+              "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+              "dev": true
+            },
+            "window-size": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+              "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+              "dev": true
+            },
+            "yargs": {
+              "version": "3.27.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+              "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
+              "dev": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "os-locale": "1.4.0",
+                "window-size": "0.1.4",
+                "y18n": "3.2.1"
+              }
+            }
+          }
+        },
+        "deglob": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/deglob/-/deglob-1.1.2.tgz",
+          "integrity": "sha1-dtV3wl/j9zKUEqK1nq3qV6xQDj8=",
+          "dev": true,
+          "requires": {
+            "find-root": "1.1.0",
+            "glob": "7.1.2",
+            "ignore": "3.3.8",
+            "pkg-config": "1.1.1",
+            "run-parallel": "1.1.9",
+            "uniq": "1.0.1",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "find-root": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+              "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+              "dev": true
+            }
+          }
+        },
+        "del": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+          "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+          "dev": true,
+          "requires": {
+            "globby": "5.0.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.1",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "detect-indent": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "4.0.1",
+            "minimist": "1.2.0",
+            "repeating": "1.1.3"
+          }
+        },
+        "detective": {
+          "version": "4.7.1",
+          "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+          "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.5.3",
+            "defined": "1.0.0"
+          }
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+          "dev": true,
+          "requires": {
+            "asap": "2.0.6",
+            "wrappy": "1.0.2"
+          }
+        },
+        "diff": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+          "dev": true
+        },
+        "disparity": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
+          "integrity": "sha1-V92stHMkrl9Y0swNqIbbTOnutxg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "diff": "1.4.0"
+          }
+        },
+        "doctrine": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+          "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+          "dev": true,
+          "requires": {
+            "esutils": "1.1.6",
+            "isarray": "0.0.1"
+          },
+          "dependencies": {
+            "esutils": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+              "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+              "dev": true
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "dev": true
+            }
+          }
+        },
+        "es5-ext": {
+          "version": "0.10.42",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+          "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+          "dev": true,
+          "requires": {
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1",
+            "next-tick": "1.0.0"
+          }
+        },
+        "es6-iterator": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+          "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.42",
+            "es6-symbol": "3.1.1"
+          }
+        },
+        "es6-map": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+          "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.42",
+            "es6-iterator": "2.0.3",
+            "es6-set": "0.1.5",
+            "es6-symbol": "3.1.1",
+            "event-emitter": "0.3.5"
+          }
+        },
+        "es6-set": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+          "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.42",
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1",
+            "event-emitter": "0.3.5"
+          }
+        },
+        "es6-symbol": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.42"
+          }
+        },
+        "es6-weak-map": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+          "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.42",
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "escope": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+          "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+          "dev": true,
+          "requires": {
+            "es6-map": "0.1.5",
+            "es6-weak-map": "2.0.2",
+            "esrecurse": "4.2.1",
+            "estraverse": "4.2.0"
+          }
+        },
+        "esformatter": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/esformatter/-/esformatter-0.8.2.tgz",
+          "integrity": "sha1-e6mIKqPtMIOfivds3fTxLaM3084=",
+          "dev": true,
+          "requires": {
+            "debug": "0.7.4",
+            "disparity": "2.0.0",
+            "espree": "2.2.5",
+            "glob": "5.0.15",
+            "minimist": "1.2.0",
+            "mout": "1.1.0",
+            "npm-run": "2.0.0",
+            "resolve": "1.7.1",
+            "rocambole": "0.7.0",
+            "rocambole-indent": "2.0.4",
+            "rocambole-linebreak": "1.0.2",
+            "rocambole-node": "1.0.0",
+            "rocambole-token": "1.2.1",
+            "rocambole-whitespace": "1.0.0",
+            "stdin": "0.0.1",
+            "strip-json-comments": "0.1.3",
+            "supports-color": "1.3.1",
+            "user-home": "2.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+              "dev": true
+            },
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
+              "requires": {
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "strip-json-comments": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+              "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+              "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0=",
+              "dev": true
+            }
+          }
+        },
+        "esformatter-eol-last": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/esformatter-eol-last/-/esformatter-eol-last-1.0.0.tgz",
+          "integrity": "sha1-RaeP9GIrHUnkT1a0mQV2amMpDAc=",
+          "dev": true,
+          "requires": {
+            "string.prototype.endswith": "0.2.0"
+          }
+        },
+        "esformatter-ignore": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/esformatter-ignore/-/esformatter-ignore-0.1.3.tgz",
+          "integrity": "sha1-BNO4db+knd4ATMWN9va7w8BWfx4=",
+          "dev": true
+        },
+        "esformatter-jsx": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/esformatter-jsx/-/esformatter-jsx-2.3.11.tgz",
+          "integrity": "sha1-QRxE7TJHVK+VquXe2FbVp+78td8=",
+          "dev": true,
+          "requires": {
+            "babel-core": "5.8.38",
+            "esformatter-ignore": "0.1.3",
+            "extend": "2.0.1",
+            "fresh-falafel": "1.2.0",
+            "js-beautify": "1.7.5"
+          }
+        },
+        "esformatter-literal-notation": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/esformatter-literal-notation/-/esformatter-literal-notation-1.0.1.tgz",
+          "integrity": "sha1-cQ57QgF1/j9+WvrVu60ykQOELi8=",
+          "dev": true,
+          "requires": {
+            "rocambole": "0.3.6",
+            "rocambole-token": "1.2.1"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+              "dev": true
+            },
+            "rocambole": {
+              "version": "0.3.6",
+              "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.3.6.tgz",
+              "integrity": "sha1-Teu/WUMUS8e2AG2Vvo+swLdDUqc=",
+              "dev": true,
+              "requires": {
+                "esprima": "1.0.4"
+              }
+            }
+          }
+        },
+        "esformatter-quotes": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/esformatter-quotes/-/esformatter-quotes-1.1.0.tgz",
+          "integrity": "sha1-4ixsRFx/MGBB2BybnlH8psv6yoI=",
+          "dev": true
+        },
+        "esformatter-semicolon-first": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/esformatter-semicolon-first/-/esformatter-semicolon-first-1.2.0.tgz",
+          "integrity": "sha1-47US0dTgcxDqvKv1cnfqfIpW4kI=",
+          "dev": true,
+          "requires": {
+            "esformatter-parser": "1.0.0",
+            "rocambole": "0.7.0",
+            "rocambole-linebreak": "1.0.2",
+            "rocambole-token": "1.2.1"
+          }
+        },
+        "esformatter-spaced-lined-comment": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/esformatter-spaced-lined-comment/-/esformatter-spaced-lined-comment-2.0.1.tgz",
+          "integrity": "sha1-3F80B/k8KV4eVkRr00RWDaXm3Kw=",
+          "dev": true
+        },
+        "eslint": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.9.0.tgz",
+          "integrity": "sha1-p1qvB+KGUHcu0OcNqizggwebZRQ=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "concat-stream": "1.6.2",
+            "debug": "2.6.9",
+            "doctrine": "0.7.2",
+            "escape-string-regexp": "1.0.5",
+            "escope": "3.6.0",
+            "espree": "2.2.5",
+            "estraverse": "4.2.0",
+            "estraverse-fb": "1.3.2",
+            "esutils": "2.0.2",
+            "file-entry-cache": "1.3.1",
+            "glob": "5.0.15",
+            "globals": "8.18.0",
+            "handlebars": "4.0.11",
+            "inquirer": "0.11.4",
+            "is-my-json-valid": "2.17.2",
+            "is-resolvable": "1.1.0",
+            "js-yaml": "3.11.0",
+            "json-stable-stringify": "1.0.1",
+            "lodash.clonedeep": "3.0.2",
+            "lodash.merge": "3.3.2",
+            "lodash.omit": "3.1.0",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "optionator": "0.6.0",
+            "path-is-absolute": "1.0.1",
+            "path-is-inside": "1.0.2",
+            "shelljs": "0.5.3",
+            "strip-json-comments": "1.0.4",
+            "text-table": "0.2.0",
+            "to-double-quotes": "2.0.0",
+            "to-single-quotes": "2.0.1",
+            "user-home": "2.0.0",
+            "xml-escape": "1.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
+              "requires": {
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            }
+          }
+        },
+        "eslint-config-standard": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-4.4.0.tgz",
+          "integrity": "sha1-wSl0nhmZ4M+GEHeyddnFHc2XzXU=",
+          "dev": true
+        },
+        "eslint-config-standard-react": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard-react/-/eslint-config-standard-react-1.2.1.tgz",
+          "integrity": "sha1-7QRf2yKzoP4LsL1EnPO/vq7etbM=",
+          "dev": true
+        },
+        "eslint-plugin-react": {
+          "version": "3.16.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.16.1.tgz",
+          "integrity": "sha1-Ji2Wt318SkKvgJpzwOUnpYYSKTw=",
+          "dev": true
+        },
+        "eslint-plugin-standard": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-1.3.3.tgz",
+          "integrity": "sha1-owhUUVI0MedvQJxwy4+U4yvw7H8=",
+          "dev": true
+        },
+        "espree": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
+          "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
+          "dev": true
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+          "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+          "dev": true,
+          "requires": {
+            "estraverse": "4.2.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "dev": true
+        },
+        "estraverse-fb": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
+          "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "event-emitter": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+          "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.42"
+          }
+        },
+        "exit-hook": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+          "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+          "dev": true
+        },
+        "extend": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
+          "integrity": "sha1-HugBBonnOV/5RIJByYZSvHWagmA=",
+          "dev": true
+        },
+        "fast-levenshtein": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+          "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+          "dev": true
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "file-entry-cache": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+          "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+          "dev": true,
+          "requires": {
+            "flat-cache": "1.3.0",
+            "object-assign": "4.1.1"
+          }
+        },
+        "find-root": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
+          "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE=",
+          "dev": true
+        },
+        "flat-cache": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+          "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+          "dev": true,
+          "requires": {
+            "circular-json": "0.3.3",
+            "del": "2.2.2",
+            "graceful-fs": "4.1.11",
+            "write": "0.2.1"
+          }
+        },
+        "foreach": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+          "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+          "dev": true
+        },
+        "fresh-falafel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/fresh-falafel/-/fresh-falafel-1.2.0.tgz",
+          "integrity": "sha1-WWbe6V+zXSopsS0vJRaLFyJeS2w=",
+          "dev": true,
+          "requires": {
+            "acorn": "1.2.2",
+            "foreach": "2.0.5",
+            "isarray": "0.0.1",
+            "object-keys": "1.0.11"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+              "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
+              "dev": true
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "dev": true
+            }
+          }
+        },
+        "fs-readdir-recursive": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+          "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk=",
+          "dev": true
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+          "dev": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+          "dev": true,
+          "requires": {
+            "is-property": "1.0.2"
+          }
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "dev": true
+        },
+        "globals": {
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
+          "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
+          "dev": true
+        },
+        "globby": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "home-or-tmp": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "1.0.2",
+            "user-home": "1.1.1"
+          },
+          "dependencies": {
+            "user-home": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+              "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+              "dev": true
+            }
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.22",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.22.tgz",
+          "integrity": "sha512-1AinFBeDTnsvVEP+V1QBlHpM1UZZl7gWB6fcz7B1Ho+LI1dUh2sSrxoCfVt2PinRHzXAziSniEV3P7JbTDHcXA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore": {
+          "version": "3.3.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+          "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "0.11.4",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
+          "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "1.1.1",
+            "figures": "1.7.0",
+            "lodash": "3.10.1",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-integer": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
+          "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.17.2",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+          "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+          "dev": true,
+          "requires": {
+            "generate-function": "2.0.0",
+            "generate-object-property": "1.2.0",
+            "is-my-ip-valid": "1.0.0",
+            "jsonpointer": "4.0.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+          "dev": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+          "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+          "dev": true,
+          "requires": {
+            "is-path-inside": "1.0.1"
+          }
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+          "dev": true,
+          "requires": {
+            "path-is-inside": "1.0.2"
+          }
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+          "dev": true
+        },
+        "is-resolvable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+          "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "js-beautify": {
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.7.5.tgz",
+          "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
+          "dev": true,
+          "requires": {
+            "config-chain": "1.1.11",
+            "editorconfig": "0.13.3",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6"
+          }
+        },
+        "js-tokens": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+          "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+              "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+              "dev": true
+            }
+          }
+        },
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "dev": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json5": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
+          "dev": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+          "dev": true
+        },
+        "jsonpointer": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+          "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "dev": true
+        },
+        "leven": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
+          "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM=",
+          "dev": true
+        },
+        "levn": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+          "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
+        "lodash._arraycopy": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+          "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+          "dev": true
+        },
+        "lodash._arrayeach": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+          "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+          "dev": true
+        },
+        "lodash._arraymap": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+          "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
+          "dev": true
+        },
+        "lodash._baseassign": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+          "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+          "dev": true,
+          "requires": {
+            "lodash._basecopy": "3.0.1",
+            "lodash.keys": "3.1.2"
+          }
+        },
+        "lodash._baseclone": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+          "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+          "dev": true,
+          "requires": {
+            "lodash._arraycopy": "3.0.0",
+            "lodash._arrayeach": "3.0.0",
+            "lodash._baseassign": "3.2.0",
+            "lodash._basefor": "3.0.3",
+            "lodash.isarray": "3.0.4",
+            "lodash.keys": "3.1.2"
+          }
+        },
+        "lodash._basecopy": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+          "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+          "dev": true
+        },
+        "lodash._basedifference": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+          "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
+          "dev": true,
+          "requires": {
+            "lodash._baseindexof": "3.1.0",
+            "lodash._cacheindexof": "3.0.2",
+            "lodash._createcache": "3.1.2"
+          }
+        },
+        "lodash._baseflatten": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+          "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+          "dev": true,
+          "requires": {
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
+          }
+        },
+        "lodash._basefor": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+          "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+          "dev": true
+        },
+        "lodash._baseindexof": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+          "dev": true
+        },
+        "lodash._bindcallback": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+          "dev": true
+        },
+        "lodash._cacheindexof": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+          "dev": true
+        },
+        "lodash._createassigner": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+          "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+          "dev": true,
+          "requires": {
+            "lodash._bindcallback": "3.0.1",
+            "lodash._isiterateecall": "3.0.9",
+            "lodash.restparam": "3.6.1"
+          }
+        },
+        "lodash._createcache": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "3.9.1"
+          }
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+          "dev": true
+        },
+        "lodash._isiterateecall": {
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+          "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+          "dev": true
+        },
+        "lodash._pickbyarray": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+          "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
+          "dev": true
+        },
+        "lodash._pickbycallback": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+          "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
+          "dev": true,
+          "requires": {
+            "lodash._basefor": "3.0.3",
+            "lodash.keysin": "3.0.8"
+          }
+        },
+        "lodash.clonedeep": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+          "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+          "dev": true,
+          "requires": {
+            "lodash._baseclone": "3.3.0",
+            "lodash._bindcallback": "3.0.1"
+          }
+        },
+        "lodash.isarguments": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+          "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+          "dev": true
+        },
+        "lodash.isarray": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+          "dev": true
+        },
+        "lodash.isplainobject": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+          "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+          "dev": true,
+          "requires": {
+            "lodash._basefor": "3.0.3",
+            "lodash.isarguments": "3.1.0",
+            "lodash.keysin": "3.0.8"
+          }
+        },
+        "lodash.istypedarray": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+          "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+          "dev": true
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
+          }
+        },
+        "lodash.keysin": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+          "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+          "dev": true,
+          "requires": {
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
+          }
+        },
+        "lodash.merge": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+          "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
+          "dev": true,
+          "requires": {
+            "lodash._arraycopy": "3.0.0",
+            "lodash._arrayeach": "3.0.0",
+            "lodash._createassigner": "3.1.1",
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4",
+            "lodash.isplainobject": "3.2.0",
+            "lodash.istypedarray": "3.0.6",
+            "lodash.keys": "3.1.2",
+            "lodash.keysin": "3.0.8",
+            "lodash.toplainobject": "3.0.0"
+          }
+        },
+        "lodash.omit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+          "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
+          "dev": true,
+          "requires": {
+            "lodash._arraymap": "3.0.0",
+            "lodash._basedifference": "3.0.3",
+            "lodash._baseflatten": "3.1.4",
+            "lodash._bindcallback": "3.0.1",
+            "lodash._pickbyarray": "3.0.2",
+            "lodash._pickbycallback": "3.0.0",
+            "lodash.keysin": "3.0.8",
+            "lodash.restparam": "3.6.1"
+          }
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+          "dev": true
+        },
+        "lodash.toplainobject": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+          "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
+          "dev": true,
+          "requires": {
+            "lodash._basecopy": "3.0.1",
+            "lodash.keysin": "3.0.8"
+          }
+        },
+        "longest": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "mout": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/mout/-/mout-1.1.0.tgz",
+          "integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "multiline": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/multiline/-/multiline-1.0.2.tgz",
+          "integrity": "sha1-abHyX/B00oKJBPJE3dBrfZbvbJM=",
+          "dev": true,
+          "requires": {
+            "strip-indent": "1.0.1"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+          "dev": true
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.1"
+          }
+        },
+        "npm-path": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-1.1.0.tgz",
+          "integrity": "sha1-BHSuAEGcMn1UcBt88s0F3Ii+EUA=",
+          "dev": true,
+          "requires": {
+            "which": "1.2.14"
+          }
+        },
+        "npm-run": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/npm-run/-/npm-run-2.0.0.tgz",
+          "integrity": "sha1-KN/ArV4uRv4ISOK9WN3wAue3PBU=",
+          "dev": true,
+          "requires": {
+            "minimist": "1.2.0",
+            "npm-path": "1.1.0",
+            "npm-which": "2.0.0",
+            "serializerr": "1.0.3",
+            "spawn-sync": "1.0.15",
+            "sync-exec": "0.5.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+              "dev": true
+            }
+          }
+        },
+        "optionator": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz",
+          "integrity": "sha1-tj7Lvw4xX61LyYJ7Rdx7pFKE/LY=",
+          "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "1.0.7",
+            "levn": "0.2.5",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "dev": true
+        },
+        "output-file-sync": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+          "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "pkg-config": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+          "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+          "dev": true,
+          "requires": {
+            "debug-log": "1.0.1",
+            "find-root": "1.1.0",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "find-root": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+              "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+              "dev": true
+            }
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "dev": true
+        },
+        "private": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+          "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "dev": true
+        },
+        "proto-list": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+          "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+          "dev": true
+        },
+        "protochain": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/protochain/-/protochain-1.0.5.tgz",
+          "integrity": "sha1-mRxAfpneJkqt+PgVBLXn+ve/omA=",
+          "dev": true
+        },
+        "q": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+          "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "readline2": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+          "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "mute-stream": "0.0.5"
+          }
+        },
+        "recast": {
+          "version": "0.10.33",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+          "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
+          "dev": true,
+          "requires": {
+            "ast-types": "0.8.12",
+            "esprima-fb": "15001.1001.0-dev-harmony-fb",
+            "private": "0.1.8",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "ast-types": {
+              "version": "0.8.12",
+              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+              "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
+              "dev": true
+            },
+            "esprima-fb": {
+              "version": "15001.1001.0-dev-harmony-fb",
+              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+              "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+              "dev": true
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "regenerate": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+          "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+          "dev": true
+        },
+        "regenerator": {
+          "version": "0.8.40",
+          "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+          "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
+          "dev": true,
+          "requires": {
+            "commoner": "0.10.8",
+            "defs": "1.1.1",
+            "esprima-fb": "15001.1001.0-dev-harmony-fb",
+            "private": "0.1.8",
+            "recast": "0.10.33",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "esprima-fb": {
+              "version": "15001.1001.0-dev-harmony-fb",
+              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+              "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+              "dev": true
+            }
+          }
+        },
+        "regexpu": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+          "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
+          "dev": true,
+          "requires": {
+            "esprima": "2.7.3",
+            "recast": "0.10.33",
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+              "dev": true
+            }
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+          "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+          "dev": true,
+          "requires": {
+            "jsesc": "0.5.0"
+          }
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "dev": true
+        },
+        "repeating": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "resolve": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+          "dev": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
+        },
+        "rocambole": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
+          "integrity": "sha1-9seVBVF9xCtvuECEK4uVOw+WhYU=",
+          "dev": true,
+          "requires": {
+            "esprima": "2.7.3"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+              "dev": true
+            }
+          }
+        },
+        "rocambole-indent": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/rocambole-indent/-/rocambole-indent-2.0.4.tgz",
+          "integrity": "sha1-oYokl3ygQAuGHapGMehh3LUtCFw=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "mout": "0.11.1",
+            "rocambole-token": "1.2.1"
+          },
+          "dependencies": {
+            "mout": {
+              "version": "0.11.1",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
+              "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k=",
+              "dev": true
+            }
+          }
+        },
+        "rocambole-linebreak": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/rocambole-linebreak/-/rocambole-linebreak-1.0.2.tgz",
+          "integrity": "sha1-A2IVFbQ7RyHJflocG8paA2Y2jy8=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "rocambole-token": "1.2.1",
+            "semver": "4.3.6"
+          }
+        },
+        "rocambole-node": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/rocambole-node/-/rocambole-node-1.0.0.tgz",
+          "integrity": "sha1-21tJ3nQHsAgN1RSHLyjjk9D3/z8=",
+          "dev": true
+        },
+        "rocambole-token": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz",
+          "integrity": "sha1-x4XfdCjcPLJ614lwR71SOMwHDTU=",
+          "dev": true
+        },
+        "rocambole-whitespace": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/rocambole-whitespace/-/rocambole-whitespace-1.0.0.tgz",
+          "integrity": "sha1-YzMJSSVrKZQfWbGQRZ+ZnGsdO/k=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "repeat-string": "1.6.1",
+            "rocambole-token": "1.2.1"
+          }
+        },
+        "run-async": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+          "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        },
+        "run-parallel": {
+          "version": "1.1.9",
+          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+          "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+          "dev": true
+        },
+        "rx-lite": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+          "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true
+        },
+        "serializerr": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/serializerr/-/serializerr-1.0.3.tgz",
+          "integrity": "sha1-EtTFqhw/+49tHcXzlaqUVVacP5E=",
+          "dev": true,
+          "requires": {
+            "protochain": "1.0.5"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+          "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
+          "dev": true
+        },
+        "simple-fmt": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+          "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms=",
+          "dev": true
+        },
+        "simple-is": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+          "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
+          "dev": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        },
+        "source-map-support": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+          "dev": true,
+          "requires": {
+            "source-map": "0.1.32"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
+            }
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        },
+        "stable": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+          "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+          "dev": true
+        },
+        "standard-engine": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-2.2.5.tgz",
+          "integrity": "sha1-ornUQZ9kiiIbjReCP7dFQG83w04=",
+          "dev": true,
+          "requires": {
+            "defaults": "1.0.3",
+            "deglob": "1.1.2",
+            "dezalgo": "1.0.3",
+            "eslint": "1.9.0",
+            "find-root": "0.1.2",
+            "get-stdin": "4.0.1",
+            "minimist": "1.2.0",
+            "multiline": "1.0.2",
+            "pkg-config": "1.1.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "standard-format": {
+          "version": "1.6.10",
+          "resolved": "https://registry.npmjs.org/standard-format/-/standard-format-1.6.10.tgz",
+          "integrity": "sha1-sYPI+DfI05OHmPPQlD5dgHoboD8=",
+          "dev": true,
+          "requires": {
+            "deglob": "1.1.2",
+            "esformatter": "0.8.2",
+            "esformatter-eol-last": "1.0.0",
+            "esformatter-jsx": "2.3.11",
+            "esformatter-literal-notation": "1.0.1",
+            "esformatter-quotes": "1.1.0",
+            "esformatter-semicolon-first": "1.2.0",
+            "esformatter-spaced-lined-comment": "2.0.1",
+            "minimist": "1.2.0",
+            "stdin": "0.0.1"
+          }
+        },
+        "stdin": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz",
+          "integrity": "sha1-0wQZgarsPf28d6GzjWNy449ftx4=",
+          "dev": true
+        },
+        "string.prototype.endswith": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
+          "integrity": "sha1-oZwg3uUamHd+mkfhDwm+OTubunU=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "stringmap": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
+          "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE=",
+          "dev": true
+        },
+        "stringset": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+          "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "4.0.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "sync-exec": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.5.0.tgz",
+          "integrity": "sha1-P3JY5KW6FyRTgZCfpqb2z1BuFmE=",
+          "dev": true
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "dev": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+          "dev": true
+        },
+        "to-double-quotes": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz",
+          "integrity": "sha1-qvIx1vqUiUn4GTAburRITYWI5Kc=",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
+        },
+        "to-single-quotes": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.1.tgz",
+          "integrity": "sha1-fMKRUfD18sQZRvEZ9ZMv5VQXASU=",
+          "dev": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+          "dev": true
+        },
+        "try-resolve": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+          "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI=",
+          "dev": true
+        },
+        "tryor": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+          "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=",
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "1.1.2"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+          "dev": true,
+          "optional": true
+        },
+        "uniq": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+          "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+          "dev": true
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+          "dev": true,
+          "requires": {
+            "os-homedir": "1.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+          "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+          "dev": true,
+          "requires": {
+            "mkdirp": "0.5.1"
+          }
+        },
+        "xml-escape": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
+          "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
     },
-    "standard-engine": {
-      "version": "https://registry.npmjs.org/standard-engine/-/standard-engine-2.2.5.tgz",
-      "integrity": "sha1-ornUQZ9kiiIbjReCP7dFQG83w04=",
-      "dev": true
-    },
-    "standard-format": {
-      "version": "https://registry.npmjs.org/standard-format/-/standard-format-1.6.10.tgz",
-      "integrity": "sha1-sYPI+DfI05OHmPPQlD5dgHoboD8=",
-      "dev": true
-    },
-    "stdin": {
-      "version": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz",
-      "integrity": "sha1-0wQZgarsPf28d6GzjWNy449ftx4=",
-      "dev": true
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
+      }
     },
     "string_decoder": {
       "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
-    "string.prototype.endswith": {
-      "version": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
-      "integrity": "sha1-oZwg3uUamHd+mkfhDwm+OTubunU=",
-      "dev": true
-    },
-    "stringmap": {
-      "version": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
-      "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE=",
-      "dev": true
-    },
-    "stringset": {
-      "version": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
-      "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
       "dev": true
     },
     "stringstream": {
@@ -1958,26 +3986,14 @@
     "strip-ansi": {
       "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
       "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
-      "dev": true
-    },
-    "strip-indent": {
-      "version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true
-    },
-    "strip-json-comments": {
-      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+      }
     },
     "supports-color": {
       "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
-    },
-    "sync-exec": {
-      "version": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.5.0.tgz",
-      "integrity": "sha1-P3JY5KW6FyRTgZCfpqb2z1BuFmE=",
       "dev": true
     },
     "tap": {
@@ -1985,6 +4001,35 @@
       "resolved": "https://registry.npmjs.org/tap/-/tap-10.3.3.tgz",
       "integrity": "sha512-ELPgkGOlrS4fj2iX7CFg9oJ4kGcA8xYurvtJhRN+O/CI52X+vSpHdahjx71ABX3Y774XcPKouU+DYB9lqrR2uQ==",
       "dev": true,
+      "requires": {
+        "bind-obj-methods": "1.0.0",
+        "bluebird": "3.5.0",
+        "clean-yaml-object": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
+        "color-support": "https://registry.npmjs.org/color-support/-/color-support-1.1.2.tgz",
+        "coveralls": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.15.tgz",
+        "deeper": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz",
+        "foreground-child": "1.5.6",
+        "fs-exists-cached": "1.0.0",
+        "function-loop": "1.0.1",
+        "glob": "7.1.2",
+        "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
+        "nyc": "11.0.2",
+        "only-shallow": "https://registry.npmjs.org/only-shallow/-/only-shallow-1.2.0.tgz",
+        "opener": "https://registry.npmjs.org/opener/-/opener-1.4.2.tgz",
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+        "own-or": "1.0.0",
+        "own-or-env": "1.0.0",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+        "signal-exit": "3.0.2",
+        "source-map-support": "0.4.15",
+        "stack-utils": "1.0.1",
+        "tap-mocha-reporter": "3.0.3",
+        "tap-parser": "5.3.3",
+        "tmatch": "https://registry.npmjs.org/tmatch/-/tmatch-3.0.0.tgz",
+        "trivial-deferred": "1.0.1",
+        "yapool": "1.0.0"
+      },
       "dependencies": {
         "bluebird": {
           "version": "3.5.0",
@@ -2004,12 +4049,46 @@
           "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.0.2.tgz",
           "integrity": "sha512-31rRd6ME9NM17w0oPKqi51a6fzJAqYarnzQXK+iL8XaX+3H6VH0BQut7qHIgrv2mBASRic4oNi2KRgcbFODrsQ==",
           "dev": true,
+          "requires": {
+            "archy": "1.0.0",
+            "arrify": "1.0.1",
+            "caching-transform": "1.0.1",
+            "convert-source-map": "1.5.0",
+            "debug-log": "1.0.1",
+            "default-require-extensions": "1.0.0",
+            "find-cache-dir": "0.1.1",
+            "find-up": "2.1.0",
+            "foreground-child": "1.5.6",
+            "glob": "7.1.2",
+            "istanbul-lib-coverage": "1.1.1",
+            "istanbul-lib-hook": "1.0.7",
+            "istanbul-lib-instrument": "1.7.2",
+            "istanbul-lib-report": "1.1.1",
+            "istanbul-lib-source-maps": "1.2.1",
+            "istanbul-reports": "1.1.1",
+            "md5-hex": "1.3.0",
+            "merge-source-map": "1.0.3",
+            "micromatch": "2.3.11",
+            "mkdirp": "0.5.1",
+            "resolve-from": "2.0.0",
+            "rimraf": "2.6.1",
+            "signal-exit": "3.0.2",
+            "spawn-wrap": "1.3.6",
+            "test-exclude": "4.1.1",
+            "yargs": "8.0.1",
+            "yargs-parser": "5.0.0"
+          },
           "dependencies": {
             "align-text": {
               "version": "0.1.4",
               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
               "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+              }
             },
             "amdefine": {
               "version": "1.0.1",
@@ -2033,7 +4112,10 @@
               "version": "0.4.0",
               "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
               "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "default-require-extensions": "1.0.0"
+              }
             },
             "archy": {
               "version": "1.0.0",
@@ -2045,7 +4127,10 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
               "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "arr-flatten": "1.0.3"
+              }
             },
             "arr-flatten": {
               "version": "1.0.3",
@@ -2075,43 +4160,89 @@
               "version": "6.22.0",
               "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
               "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.1"
+              }
             },
             "babel-generator": {
               "version": "6.24.1",
               "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
               "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.23.0",
+                "babel-types": "6.24.1",
+                "detect-indent": "4.0.0",
+                "jsesc": "1.3.0",
+                "lodash": "4.17.4",
+                "source-map": "0.5.6",
+                "trim-right": "1.0.1"
+              }
             },
             "babel-messages": {
               "version": "6.23.0",
               "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
               "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "babel-runtime": "6.23.0"
+              }
             },
             "babel-runtime": {
               "version": "6.23.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "core-js": "2.4.1",
+                "regenerator-runtime": "0.10.5"
+              }
             },
             "babel-template": {
               "version": "6.24.1",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "babel-runtime": "6.23.0",
+                "babel-traverse": "6.24.1",
+                "babel-types": "6.24.1",
+                "babylon": "6.17.2",
+                "lodash": "4.17.4"
+              }
             },
             "babel-traverse": {
               "version": "6.24.1",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
               "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "babel-code-frame": "6.22.0",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.23.0",
+                "babel-types": "6.24.1",
+                "babylon": "6.17.2",
+                "debug": "2.6.8",
+                "globals": "9.17.0",
+                "invariant": "2.2.2",
+                "lodash": "4.17.4"
+              }
             },
             "babel-types": {
               "version": "6.24.1",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "babel-runtime": "6.23.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.4",
+                "to-fast-properties": "1.0.3"
+              }
             },
             "babylon": {
               "version": "6.17.2",
@@ -2129,13 +4260,22 @@
               "version": "1.1.7",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
               "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "balanced-match": "0.4.2",
+                "concat-map": "0.0.1"
+              }
             },
             "braces": {
               "version": "1.8.5",
               "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
               "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+              }
             },
             "builtin-modules": {
               "version": "1.1.1",
@@ -2147,20 +4287,36 @@
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
               "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "md5-hex": "1.3.0",
+                "mkdirp": "0.5.1",
+                "write-file-atomic": "1.3.4"
+              }
             },
             "center-align": {
               "version": "0.1.3",
               "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
               "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+              }
             },
             "chalk": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
             },
             "cliui": {
               "version": "2.1.0",
@@ -2168,6 +4324,11 @@
               "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
               "dev": true,
               "optional": true,
+              "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+              },
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
@@ -2212,13 +4373,20 @@
               "version": "4.0.2",
               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
               "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "lru-cache": "4.0.2",
+                "which": "1.2.14"
+              }
             },
             "debug": {
               "version": "2.6.8",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
               "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
             },
             "debug-log": {
               "version": "1.0.1",
@@ -2236,19 +4404,28 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
               "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "strip-bom": "2.0.0"
+              }
             },
             "detect-indent": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
               "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "repeating": "2.0.1"
+              }
             },
             "error-ex": {
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
               "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-arrayish": "0.2.1"
+              }
             },
             "escape-string-regexp": {
               "version": "1.0.5",
@@ -2266,25 +4443,43 @@
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
               "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "cross-spawn": "4.0.2",
+                "get-stream": "2.3.1",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+              }
             },
             "expand-brackets": {
               "version": "0.1.5",
               "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
               "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-posix-bracket": "0.1.1"
+              }
             },
             "expand-range": {
               "version": "1.8.2",
               "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
               "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "fill-range": "2.2.3"
+              }
             },
             "extglob": {
               "version": "0.3.2",
               "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
               "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
             },
             "filename-regex": {
               "version": "2.0.1",
@@ -2296,19 +4491,34 @@
               "version": "2.2.3",
               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
               "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.6",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+              }
             },
             "find-cache-dir": {
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
               "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "commondir": "1.0.1",
+                "mkdirp": "0.5.1",
+                "pkg-dir": "1.0.0"
+              }
             },
             "find-up": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "locate-path": "2.0.0"
+              }
             },
             "for-in": {
               "version": "1.0.2",
@@ -2320,13 +4530,20 @@
               "version": "0.1.5",
               "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
               "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "for-in": "1.0.2"
+              }
             },
             "foreground-child": {
               "version": "1.5.6",
               "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
               "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "cross-spawn": "4.0.2",
+                "signal-exit": "3.0.2"
+              }
             },
             "fs.realpath": {
               "version": "1.0.0",
@@ -2344,25 +4561,44 @@
               "version": "2.3.1",
               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
               "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "object-assign": "4.1.1",
+                "pinkie-promise": "2.0.1"
+              }
             },
             "glob": {
               "version": "7.1.2",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
             },
             "glob-base": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
               "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+              }
             },
             "glob-parent": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
               "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-glob": "2.0.1"
+              }
             },
             "globals": {
               "version": "9.17.0",
@@ -2381,12 +4617,21 @@
               "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
               "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
               "dev": true,
+              "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.8.27"
+              },
               "dependencies": {
                 "source-map": {
                   "version": "0.4.4",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "amdefine": "1.0.1"
+                  }
                 }
               }
             },
@@ -2394,7 +4639,10 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
             },
             "has-flag": {
               "version": "1.0.0",
@@ -2418,7 +4666,11 @@
               "version": "1.0.6",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
             },
             "inherits": {
               "version": "2.0.3",
@@ -2430,7 +4682,10 @@
               "version": "2.2.2",
               "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
               "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "loose-envify": "1.3.1"
+              }
             },
             "invert-kv": {
               "version": "1.0.0",
@@ -2454,7 +4709,10 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
               "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              }
             },
             "is-dotfile": {
               "version": "1.0.3",
@@ -2466,7 +4724,10 @@
               "version": "0.1.3",
               "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
               "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-primitive": "2.0.0"
+              }
             },
             "is-extendable": {
               "version": "0.1.1",
@@ -2484,25 +4745,37 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
               "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
             },
             "is-glob": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
             },
             "is-number": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
               "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
             },
             "is-posix-bracket": {
               "version": "0.1.1",
@@ -2544,7 +4817,10 @@
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
             },
             "istanbul-lib-coverage": {
               "version": "1.1.1",
@@ -2556,25 +4832,46 @@
               "version": "1.0.7",
               "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
               "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "append-transform": "0.4.0"
+              }
             },
             "istanbul-lib-instrument": {
               "version": "1.7.2",
               "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.2.tgz",
               "integrity": "sha512-lPgUY+Pa5dlq2/l0qs1PJZ54QPSfo+s4+UZdkb2d0hbOyrEIAbUJphBLFjEyXBdeCONgGRADFzs3ojfFtmuwFA==",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "babel-generator": "6.24.1",
+                "babel-template": "6.24.1",
+                "babel-traverse": "6.24.1",
+                "babel-types": "6.24.1",
+                "babylon": "6.17.2",
+                "istanbul-lib-coverage": "1.1.1",
+                "semver": "5.3.0"
+              }
             },
             "istanbul-lib-report": {
               "version": "1.1.1",
               "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
               "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
               "dev": true,
+              "requires": {
+                "istanbul-lib-coverage": "1.1.1",
+                "mkdirp": "0.5.1",
+                "path-parse": "1.0.5",
+                "supports-color": "3.2.3"
+              },
               "dependencies": {
                 "supports-color": {
                   "version": "3.2.3",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                   "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "1.0.0"
+                  }
                 }
               }
             },
@@ -2582,13 +4879,23 @@
               "version": "1.2.1",
               "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
               "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "debug": "2.6.8",
+                "istanbul-lib-coverage": "1.1.1",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1",
+                "source-map": "0.5.6"
+              }
             },
             "istanbul-reports": {
               "version": "1.1.1",
               "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
               "integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw==",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "handlebars": "4.0.10"
+              }
             },
             "js-tokens": {
               "version": "3.0.1",
@@ -2606,7 +4913,10 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
             },
             "lazy-cache": {
               "version": "1.0.4",
@@ -2619,19 +4929,33 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
               "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "invert-kv": "1.0.0"
+              }
             },
             "load-json-file": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
               "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
+              }
             },
             "locate-path": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
               "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
               "dev": true,
+              "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+              },
               "dependencies": {
                 "path-exists": {
                   "version": "3.0.0",
@@ -2657,19 +4981,29 @@
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
               "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "js-tokens": "3.0.1"
+              }
             },
             "lru-cache": {
               "version": "4.0.2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
               "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+              }
             },
             "md5-hex": {
               "version": "1.3.0",
               "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
               "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "md5-o-matic": "0.1.1"
+              }
             },
             "md5-o-matic": {
               "version": "0.1.1",
@@ -2681,19 +5015,40 @@
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
               "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "mimic-fn": "1.1.0"
+              }
             },
             "merge-source-map": {
               "version": "1.0.3",
               "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.3.tgz",
               "integrity": "sha1-2hQV8nIqURnbB7FMT5c0EIY6Kr8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "source-map": "0.5.6"
+              }
             },
             "micromatch": {
               "version": "2.3.11",
               "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
               "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.3"
+              }
             },
             "mimic-fn": {
               "version": "1.1.0",
@@ -2705,7 +5060,10 @@
               "version": "3.0.4",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.7"
+              }
             },
             "minimist": {
               "version": "0.0.8",
@@ -2717,7 +5075,10 @@
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
             },
             "ms": {
               "version": "2.0.0",
@@ -2729,19 +5090,31 @@
               "version": "2.3.8",
               "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
               "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "hosted-git-info": "2.4.2",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.3.0",
+                "validate-npm-package-license": "3.0.1"
+              }
             },
             "normalize-path": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "remove-trailing-separator": "1.0.1"
+              }
             },
             "npm-run-path": {
               "version": "2.0.2",
               "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
               "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "path-key": "2.0.1"
+              }
             },
             "number-is-nan": {
               "version": "1.0.1",
@@ -2759,19 +5132,30 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
               "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+              }
             },
             "once": {
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
             },
             "optimist": {
               "version": "0.6.1",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8",
+                "wordwrap": "0.0.3"
+              }
             },
             "os-homedir": {
               "version": "1.0.2",
@@ -2783,7 +5167,12 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
               "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "execa": "0.5.1",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
+              }
             },
             "p-finally": {
               "version": "1.0.0",
@@ -2801,25 +5190,40 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
               "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "p-limit": "1.1.0"
+              }
             },
             "parse-glob": {
               "version": "3.0.4",
               "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
               "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+              }
             },
             "parse-json": {
               "version": "2.2.0",
               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
               "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "error-ex": "1.3.1"
+              }
             },
             "path-exists": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
               "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "pinkie-promise": "2.0.1"
+              }
             },
             "path-is-absolute": {
               "version": "1.0.1",
@@ -2843,7 +5247,12 @@
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
               "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+              }
             },
             "pify": {
               "version": "2.3.0",
@@ -2861,19 +5270,29 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "pinkie": "2.0.4"
+              }
             },
             "pkg-dir": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
               "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
               "dev": true,
+              "requires": {
+                "find-up": "1.1.2"
+              },
               "dependencies": {
                 "find-up": {
                   "version": "1.1.2",
                   "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                   "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
                 }
               }
             },
@@ -2893,25 +5312,42 @@
               "version": "1.1.6",
               "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
               "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-number": "2.1.0",
+                "kind-of": "3.2.2"
+              }
             },
             "read-pkg": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
               "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.3.8",
+                "path-type": "1.1.0"
+              }
             },
             "read-pkg-up": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
               "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
               "dev": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              },
               "dependencies": {
                 "find-up": {
                   "version": "1.1.2",
                   "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                   "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
                 }
               }
             },
@@ -2925,7 +5361,11 @@
               "version": "0.4.3",
               "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
               "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-equal-shallow": "0.1.3",
+                "is-primitive": "2.0.0"
+              }
             },
             "remove-trailing-separator": {
               "version": "1.0.1",
@@ -2949,7 +5389,10 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
               "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-finite": "1.0.2"
+              }
             },
             "require-directory": {
               "version": "2.1.1",
@@ -2974,13 +5417,19 @@
               "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
               "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "align-text": "0.1.4"
+              }
             },
             "rimraf": {
               "version": "2.6.1",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
               "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "glob": "7.1.2"
+              }
             },
             "semver": {
               "version": "5.3.0",
@@ -3016,13 +5465,24 @@
               "version": "1.3.6",
               "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.6.tgz",
               "integrity": "sha512-5bEhZ11kqwoECJwfbur2ALU1NBnnCNbFzdWGHEXCiSsVhH+Ubz6eesa1DuQcm05pk38HknqP556f3CFhqws2ZA==",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "foreground-child": "1.5.6",
+                "mkdirp": "0.5.1",
+                "os-homedir": "1.0.2",
+                "rimraf": "2.6.1",
+                "signal-exit": "3.0.2",
+                "which": "1.2.14"
+              }
             },
             "spdx-correct": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
               "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "spdx-license-ids": "1.2.2"
+              }
             },
             "spdx-expression-parse": {
               "version": "1.0.4",
@@ -3041,6 +5501,10 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
               "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
               "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "3.0.1"
+              },
               "dependencies": {
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
@@ -3054,13 +5518,19 @@
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
             },
             "strip-bom": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
               "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              }
             },
             "strip-eof": {
               "version": "1.0.0",
@@ -3078,7 +5548,14 @@
               "version": "4.1.1",
               "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
               "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "arrify": "1.0.1",
+                "micromatch": "2.3.11",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "require-main-filename": "1.0.1"
+              }
             },
             "to-fast-properties": {
               "version": "1.0.3",
@@ -3098,6 +5575,11 @@
               "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
               "dev": true,
               "optional": true,
+              "requires": {
+                "source-map": "0.5.6",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
@@ -3111,7 +5593,13 @@
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                   "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                   "dev": true,
-                  "optional": true
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "window-size": "0.1.0"
+                  }
                 }
               }
             },
@@ -3126,13 +5614,20 @@
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
               "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
+              }
             },
             "which": {
               "version": "1.2.14",
               "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
               "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "isexe": "2.0.0"
+              }
             },
             "which-module": {
               "version": "2.0.0",
@@ -3158,12 +5653,21 @@
               "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
               "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
               "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+              },
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
                 }
               }
             },
@@ -3177,7 +5681,12 @@
               "version": "1.3.4",
               "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
               "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
+              }
             },
             "y18n": {
               "version": "3.2.1",
@@ -3196,6 +5705,21 @@
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz",
               "integrity": "sha1-Qg73XoQMFFeoCtzKm8b6OEneUao=",
               "dev": true,
+              "requires": {
+                "camelcase": "4.1.0",
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.0.0",
+                "read-pkg-up": "2.0.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.0.0",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "7.0.0"
+              },
               "dependencies": {
                 "camelcase": {
                   "version": "4.1.0",
@@ -3208,12 +5732,22 @@
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
                   "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                   "dev": true,
+                  "requires": {
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wrap-ansi": "2.1.0"
+                  },
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
                       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      }
                     }
                   }
                 },
@@ -3221,25 +5755,43 @@
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
                   "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "parse-json": "2.2.0",
+                    "pify": "2.3.0",
+                    "strip-bom": "3.0.0"
+                  }
                 },
                 "path-type": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
                   "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "pify": "2.3.0"
+                  }
                 },
                 "read-pkg": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
                   "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "load-json-file": "2.0.0",
+                    "normalize-package-data": "2.3.8",
+                    "path-type": "2.0.0"
+                  }
                 },
                 "read-pkg-up": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
                   "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "find-up": "2.1.0",
+                    "read-pkg": "2.0.0"
+                  }
                 },
                 "strip-bom": {
                   "version": "3.0.0",
@@ -3251,7 +5803,10 @@
                   "version": "7.0.0",
                   "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
                   "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "camelcase": "4.1.0"
+                  }
                 }
               }
             },
@@ -3260,6 +5815,9 @@
               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
               "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
               "dev": true,
+              "requires": {
+                "camelcase": "3.0.0"
+              },
               "dependencies": {
                 "camelcase": {
                   "version": "3.0.0",
@@ -3287,7 +5845,10 @@
           "version": "0.4.15",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
           "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.6"
+          }
         },
         "stack-utils": {
           "version": "1.0.1",
@@ -3300,20 +5861,43 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "tap-mocha-reporter": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.3.tgz",
           "integrity": "sha1-5ZF/rT2acJV/m3xzbnk764fX2vE=",
           "dev": true,
+          "requires": {
+            "color-support": "https://registry.npmjs.org/color-support/-/color-support-1.1.2.tgz",
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "diff": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
+            "glob": "7.1.2",
+            "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
+            "readable-stream": "2.2.11",
+            "tap-parser": "5.3.3",
+            "unicode-length": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "2.2.11",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
               "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                "isarray": "1.0.0",
+                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                "safe-buffer": "5.0.1",
+                "string_decoder": "1.0.2",
+                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+              }
             }
           }
         },
@@ -3321,69 +5905,32 @@
           "version": "5.3.3",
           "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.3.3.tgz",
           "integrity": "sha1-U+yKkPJ11v/0PxaeVqZ5UCp0EYU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "events-to-array": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.0.2.tgz",
+            "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+          }
         }
       }
-    },
-    "text-table": {
-      "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "through": {
-      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
     },
     "tmatch": {
       "version": "https://registry.npmjs.org/tmatch/-/tmatch-3.0.0.tgz",
       "integrity": "sha1-fSBx3tu8WH8ZSs2jBnvQdHtnCZE=",
       "dev": true
     },
-    "to-double-quotes": {
-      "version": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz",
-      "integrity": "sha1-qvIx1vqUiUn4GTAburRITYWI5Kc=",
-      "dev": true
-    },
-    "to-fast-properties": {
-      "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
-      "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg=",
-      "dev": true
-    },
-    "to-single-quotes": {
-      "version": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.0.tgz",
-      "integrity": "sha1-WHeVL4MOafx+4ZsHcjYqU7mBF4A=",
-      "dev": true
-    },
     "tough-cookie": {
       "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true
-    },
-    "trim-right": {
-      "version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+      }
     },
     "trivial-deferred": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
       "integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM=",
-      "dev": true
-    },
-    "try-resolve": {
-      "version": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
-      "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI=",
-      "dev": true
-    },
-    "tryit": {
-      "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz",
-      "integrity": "sha1-wZawBz5rHFldk8nIMIVbeswypFM=",
-      "dev": true
-    },
-    "tryor": {
-      "version": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
-      "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=",
       "dev": true
     },
     "tunnel-agent": {
@@ -3397,66 +5944,25 @@
       "dev": true,
       "optional": true
     },
-    "type-check": {
-      "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
-      "integrity": "sha1-kjOSPE2hdNCsVIDs/W74TDSetY0=",
-      "dev": true
-    },
-    "typedarray": {
-      "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "uglify-js": {
-      "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
-      "integrity": "sha1-7bvhiIujUl3tOnv4NrMLNAXTFhs=",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
-    },
     "unicode-length": {
       "version": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
       "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
       "dev": true,
+      "requires": {
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+        "strip-ansi": "3.0.1"
+      },
       "dependencies": {
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+          }
         }
       }
-    },
-    "uniq": {
-      "version": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-      "dev": true
-    },
-    "user-home": {
-      "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true
     },
     "util-deprecate": {
       "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3466,13 +5972,19 @@
     "verror": {
       "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+      }
     },
     "which": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      },
       "dependencies": {
         "isexe": {
           "version": "2.0.0",
@@ -3482,30 +5994,9 @@
         }
       }
     },
-    "window-size": {
-      "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
-      "optional": true
-    },
-    "wordwrap": {
-      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
-    },
     "wrappy": {
       "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
       "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
-      "dev": true
-    },
-    "write": {
-      "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
-    },
-    "xml-escape": {
-      "version": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
-      "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
       "dev": true
     },
     "xtend": {
@@ -3529,12 +6020,6 @@
       "resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
       "integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o=",
       "dev": true
-    },
-    "yargs": {
-      "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true,
-      "optional": true
     }
   }
 }

--- a/test/no-symbol-for.js
+++ b/test/no-symbol-for.js
@@ -1,0 +1,13 @@
+var test = require('tap').test
+global.Symbol = function Symbol () {}
+var LRU = require('../')
+
+test('basic', function (t) {
+  var cache = new LRU({max: 10})
+  cache.set('key', 'value')
+  t.equal(cache.get('key'), 'value')
+  t.equal(cache.get('nada'), undefined)
+  t.equal(cache.length, 1)
+  t.equal(cache.max, 10)
+  t.end()
+})


### PR DESCRIPTION
This fixes a problem when loading the Google Maps Places API in IE11 when this library is used. The Maps API ships an incomplete polyfill of `Symbol` that does not include `Symbol.for`. The incomplete polyfill is coming from `https://maps.googleapis.com/maps/api/js?libraries=places&key=...redacted...` which is how to load the Places API per https://developers.google.com/maps/documentation/javascript/places . 