### PR TITLE
Throwing on set when `isNaN(maxAge)`

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,6 +153,9 @@ class LRUCache {
   set (key, value, maxAge) {
     maxAge = maxAge || this[MAX_AGE]
 
+    if (maxAge && typeof maxAge !== 'number')
+      throw new TypeError('maxAge must be a number')
+
     const now = maxAge ? Date.now() : 0
     const len = this[LENGTH_CALCULATOR](value, key)
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -559,3 +559,13 @@ test('update age on get', t => {
   t.ok(e2 < e3, 'time updated on second get')
   t.end()
 })
+
+test('drop the old items with set override maxAge', function (t) {
+  var cache = new LRU({
+    max: 2
+  })
+   t.throw(function setMaxAgeWithAObject () {
+    cache.set('a', 'A', {expire: 20})
+  }, 'maxAge must be a number')
+  t.end()
+})


### PR DESCRIPTION
One thing on #136 was the check on set override.
I actually I have another test coming