### PR TITLE
Add support Node versions to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "lru",
     "cache"
   ],
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "scripts": {
     "test": "tap test/*.js --100 -J",
     "snap": "TAP_SNAPSHOT=1 tap test/*.js -J",


### PR DESCRIPTION
Document supported Node.js versions so tools can verify that modules they don't rely on modules with a narrower node.js dependency than they have themselves.

Reference: https://github.com/isaacs/node-lru-cache/commit/9ce69193c4cefbeee27e759b1cf94e02a3eadf8b