### PR TITLE
Chore: Update usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install lru-cache --save
 ## Usage:
 
 ```javascript
-var LRU = require("lru-cache")
+var new LRU = require("lru-cache")
   , options = { max: 500
               , length: function (n, key) { return n * 2 + key.length }
               , dispose: function (key, n) { n.close() }


### PR DESCRIPTION
Since in lru-cache version 5, I must initialize the constructor using `new` keyword. Otherwise it will rise an error like this 
```
Class constructor LRUCache cannot be invoked without 'new'
```