### PR TITLE
Expose Entry#now and maxAge through getCachedTime(key), getMaxAge(key) method

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ away.
     Neither of these will update "recently used"-ness of the key.
     They are self explanatory in that they get the maxAge of a key
     (or globally configured max-age if none is defined for the key)
-    
-    and the time cached.
+    and the time cached as a JS timestamp (millis since epoch) respectively.
 
     if no key exists, they will return undefined.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,19 @@ away.
 
     The key and val can be any value.
 
+* `getMaxAge(key)`
+* `getCachedTime(key)`
+
+    Neither of these will update "recently used"-ness of the key.
+    They are self explanatory in that they get the maxAge of a key
+    (or globally configured max-age if none is defined for the key)
+    
+    and the time cached.
+
+    if no key exists, they will return undefined.
+
+    `getCachedTime` will return 0 if no maxAge is set.
+
 * `peek(key)`
 
     Returns the key value (or `undefined` if not found) without

--- a/index.js
+++ b/index.js
@@ -212,6 +212,10 @@ class LRUCache {
     return get(this, key, true)
   }
 
+  getCachedTime (key) {
+    return getCachedTime(this, key)
+  }
+
   peek (key) {
     return get(this, key, false)
   }
@@ -272,6 +276,19 @@ const get = (self, key, doUse) => {
       }
     }
     return hit.value
+  }
+}
+
+const getCachedTime = (self, key) => {
+  const node = self[CACHE].get(key)
+  if (node) {
+    const hit = node.value
+    if (isStale(self, hit)) {
+      if (!self[ALLOW_STALE]) {
+        return undefined
+      }
+    }
+    return hit.now
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -216,6 +216,10 @@ class LRUCache {
     return getCachedTime(this, key)
   }
 
+  getMaxAge (key) {
+    return getMaxAge(this, key)
+  }
+
   peek (key) {
     return get(this, key, false)
   }
@@ -289,6 +293,19 @@ const getCachedTime = (self, key) => {
       }
     }
     return hit.now
+  }
+}
+
+const getMaxAge = (self, key) => {
+  const node = self[CACHE].get(key)
+  if (node) {
+    const hit = node.value
+    if (isStale(self, hit)) {
+      if (!self[ALLOW_STALE]) {
+        return undefined
+      }
+    }
+    return hit.maxAge || self[MAX_AGE]
   }
 }
 


### PR DESCRIPTION
While using this library, I found myself wanting to get the metadata of entries (the cached time, and the maxAge). It was easy enough to implement and I decided to make it a PR.

I was unsure whether I should delete a stale entry when peeking at the metadata, and allowStale is false or not. I opted to make this new feature as non-intrusive as possible and not to modify the cache, but this can be changed if desired.