### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - node
+  - 14
   - 12
   - 10
 
@@ -9,9 +10,18 @@ os:
   - linux
   - windows
 
+arch:
+  - amd64
+  - ppc64le
+
 cache:
   directories:
     - $HOME/.npm
+    
+jobs:
+  exclude:
+     - arch: ppc64le
+       os: windows
 
 notifications:
   email: false


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.