### PR TITLE
add CI workflow using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        node_version:
+          - 16
+          - 14
+          - 12
+          - 10
+    runs-on: ${{ matrix.os }}
+    name: Node.js ${{ matrix.node_version }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node_version }}
+      - name: Install Node.js packages
+        run: npm install
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
Since building on [travis-ci.org](https://travis-ci.org/) has ceased on 15th June 2021, this project should use an alternative for CI. GitHub Actions is one possible alternative, and this pull requests attempts to use that possibility.

As with Travis CI, the GitHub Actions workflow tests on both Windows and Linux (in this case: Ubuntu 20.04). It tests on Node.js 10, 12, 14 and 16. Results of the CI run can be seen here: https://github.com/striezel-stash/node-lru-cache/actions/runs/1087652567

If this PR gets merged, then `.travis.yml` can be deleted.