### PR TITLE
Allow unbounded storage if maxSize or ttl set

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const options = {
   // the number of most recently used items to keep.
   // note that we may store fewer items than this if maxSize is hit.
 
-  max: 500, // <-- mandatory, you must give a maximum capacity
+  max: 500, // <-- Technically optional, but see "Storage Bounds Safety" below
 
   // if you wish to track item size, you must provide a maxSize
   // note that we still will only keep up to max *actual items*,
@@ -112,7 +112,11 @@ If you put more stuff in it, then items will fall out.
   may be stored if size calculation is used, and `maxSize` is exceeded.
   This must be a positive finite intger.
 
-    This option is required, and must be a positive integer.
+    At least one of `max`, `maxSize`, or `TTL` is required.  This must be a
+    positive integer if set.
+
+    **It is strongly recommended to set a `max` to prevent unbounded growth
+    of the cache.**  See "Storage Bounds Safety" below.
 
 * `maxSize` - Set to a positive integer to track the sizes of items added
   to the cache, and automatically evict items in order to stay below this
@@ -120,6 +124,13 @@ If you put more stuff in it, then items will fall out.
 
     Optional, must be a positive integer if provided.  Required if other
     size tracking features are used.
+
+    At least one of `max`, `maxSize`, or `TTL` is required.  This must be a
+    positive integer if set.
+
+    Even if size tracking is enabled, **it is strongly recommended to set a
+    `max` to prevent unbounded growth of the cache.**  See "Storage Bounds
+    Safety" below.
 
 * `sizeCalculation` - Function used to calculate the size of stored
   items.  If you're storing strings or buffers, then you probably want to
@@ -192,6 +203,17 @@ If you put more stuff in it, then items will fall out.
     Optional, but must be a positive integer in ms if specified.
 
     This may be overridden by passing an options object to `cache.set()`.
+
+    At least one of `max`, `maxSize`, or `TTL` is required.  This must be a
+    positive integer if set.
+
+    Even if ttl tracking is enabled, **it is strongly recommended to set a
+    `max` to prevent unbounded growth of the cache.**  See "Storage Bounds
+    Safety" below.
+
+    If ttl tracking is enabled, and `max` and `maxSize` are not set, and
+    `ttlAutopurge` is not set, then a warning will be emitted cautioning
+    about the potential for unbounded memory consumption.
 
     Deprecated alias: `maxAge`
 
@@ -466,6 +488,70 @@ ignored.
 * `head` Internal ID of least recently used item
 * `tail` Internal ID of most recently used item
 * `free` Stack of deleted internal IDs
+
+## Storage Bounds Safety
+
+This implementation aims to be as flexible as possible, within the limits
+of safe memory consumption and optimal performance.
+
+At initial object creation, storage is allocated for `max` items.  If `max`
+is set to zero, then some performance is lost, and item count is unbounded.
+Either `maxSize` or `ttl` _must_ be set if `max` is not specified.
+
+If `maxSize` is set, then this creates a safe limit on the maximum storage
+consumed, but without the performance benefits of pre-allocation.  When
+`maxSize` is set, every item _must_ provide a size, either via the
+`sizeCalculation` method provided to the constructor, or via a `size` or
+`sizeCalculation` option provided to `cache.set()`.  The size of every item
+_must_ be a positive integer.
+
+If neither `max` nor `maxSize` are set, then `ttl` tracking must be
+enabled.  Note that, even when tracking item `ttl`, items are _not_
+preemptively deleted when they become stale, unless `ttlAutopurge` is
+enabled.  Instead, they are only purged the next time the key is requested.
+Thus, if `ttlAutopurge`, `max`, and `maxSize` are all not set, then the
+cache will potentially grow unbounded.
+
+In this case, a warning is printed to standard error.  Future versions may
+require the use of `ttlAutopurge` if `max` and `maxSize` are not specified.
+
+If you truly wish to use a cache that is bound _only_ by TTL expiration,
+consider using a `Map` object, and calling `setTimeout` to delete entries
+when they expire.  It will perform much better than an LRU cache.
+
+Here is an implementation you may use, under the same [license](./LICENSE)
+as this package:
+
+```js
+// a storage-unbounded ttl cache that is not an lru-cache
+const cache = {
+  data: new Map(),
+  timers: new Map(),
+  set: (k, v, ttl) => {
+    if (cache.timers.has(k)) {
+      clearTimeout(cache.timers.get(k))
+    }
+    cache.timers.set(k, setTimeout(() => cache.del(k), ttl))
+    cache.data.set(k, v)
+  },
+  get: k => cache.data.get(k),
+  has: k => cache.data.has(k),
+  delete: k => {
+    if (cache.timers.has(k)) {
+      clearTimeout(cache.timers.get(k))
+    }
+    cache.timers.delete(k)
+    return cache.data.delete(k)
+  },
+  clear: () => {
+    cache.data.clear()
+    for (const v of cache.timers.values()) {
+      clearTimeout(v)
+    }
+    cache.timers.clear()
+  }
+}
+```
 
 ## Performance
 

--- a/tap-snapshots/test/deprecations.js.test.cjs
+++ b/tap-snapshots/test/deprecations.js.test.cjs
@@ -49,5 +49,11 @@ Array [
     "LRU_CACHE_METHOD_del",
     Function get del(),
   ],
+  Array [
+    "TTL caching without ttlAutopurge, max, or maxSize can result in unbounded memory consumption.",
+    "UnboundedCacheWarning",
+    "LRU_CACHE_UNBOUNDED",
+    Function LRUCache(classLRUCache),
+  ],
 ]
 `

--- a/tap-snapshots/test/map-like.js.test.cjs
+++ b/tap-snapshots/test/map-like.js.test.cjs
@@ -10,35 +10,35 @@ Array [
   Array [
     3,
     Object {
-      "size": 0,
+      "size": 1,
       "value": "3",
     },
   ],
   Array [
     4,
     Object {
-      "size": 0,
+      "size": 1,
       "value": "4",
     },
   ],
   Array [
     5,
     Object {
-      "size": 0,
+      "size": 1,
       "value": "5",
     },
   ],
   Array [
     6,
     Object {
-      "size": 0,
+      "size": 1,
       "value": "6",
     },
   ],
   Array [
     7,
     Object {
-      "size": 0,
+      "size": 1,
       "value": "7",
     },
   ],
@@ -50,7 +50,7 @@ Array [
   Array [
     3,
     Object {
-      "size": 0,
+      "size": 1,
       "ttl": 0,
       "value": "3",
     },
@@ -58,7 +58,7 @@ Array [
   Array [
     5,
     Object {
-      "size": 0,
+      "size": 1,
       "ttl": 0,
       "value": "5",
     },
@@ -66,7 +66,7 @@ Array [
   Array [
     6,
     Object {
-      "size": 0,
+      "size": 1,
       "ttl": 0,
       "value": "6",
     },
@@ -74,7 +74,7 @@ Array [
   Array [
     4,
     Object {
-      "size": 0,
+      "size": 1,
       "ttl": 0,
       "value": "new value 4",
     },
@@ -87,35 +87,35 @@ Array [
   Array [
     3,
     Object {
-      "size": 0,
+      "size": 1,
       "value": "3",
     },
   ],
   Array [
     5,
     Object {
-      "size": 0,
+      "size": 1,
       "value": "5",
     },
   ],
   Array [
     6,
     Object {
-      "size": 0,
+      "size": 1,
       "value": "6",
     },
   ],
   Array [
     7,
     Object {
-      "size": 0,
+      "size": 1,
       "value": "7",
     },
   ],
   Array [
     4,
     Object {
-      "size": 0,
+      "size": 1,
       "value": "new value 4",
     },
   ],

--- a/test/basic.js
+++ b/test/basic.js
@@ -86,6 +86,27 @@ t.test('bad max values', t => {
   t.throws(() => new LRU({ max: 2.5 }))
   t.throws(() => new LRU({ max: Infinity }))
   t.throws(() => new LRU({ max: Number.MAX_SAFE_INTEGER * 2 }))
+
+  // ok to have a max of 0 if maxSize or ttl are set
+  const sizeOnly = new LRU({ maxSize: 100 })
+
+  // setting the size to invalid values
+  t.throws(() => sizeOnly.set('foo', 'bar'), TypeError)
+  t.throws(() => sizeOnly.set('foo', 'bar', { size: 0 }), TypeError)
+  t.throws(() => sizeOnly.set('foo', 'bar', { size: -1 }), TypeError)
+  t.throws(() => sizeOnly.set('foo', 'bar', {
+    sizeCalculation: () => -1,
+  }), TypeError)
+  t.throws(() => sizeOnly.set('foo', 'bar', {
+    sizeCalculation: () => 0,
+  }), TypeError)
+
+  const ttlOnly = new LRU({ ttl: 1000, ttlAutopurge: true })
+  // cannot set size when not tracking size
+  t.throws(() => ttlOnly.set('foo', 'bar', { size: 1 }), TypeError)
+  t.throws(() => ttlOnly.set('foo', 'bar', { size: 1 }), TypeError)
+
+  const sizeTTL = new LRU({ maxSize: 100, ttl: 1000 })
   t.end()
 })
 

--- a/test/deprecations.js
+++ b/test/deprecations.js
@@ -18,6 +18,9 @@ t.test('warns exactly once for a given deprecation', t => {
   t.equal(c.reset, c.clear)
   t.equal(c.del, c.delete)
 
+  // not technically a "deprecation" but similar
+  new LRU({ ttl: 10 })
+
   t.matchSnapshot(warnings)
 
   warnings.length = 0
@@ -33,6 +36,8 @@ t.test('warns exactly once for a given deprecation', t => {
   t.equal(d.length, 0)
   t.equal(d.prune, d.purgeStale)
   t.equal(d.reset, d.clear)
+  new LRU({ ttl: 10 })
+
   t.strictSame(warnings, [], 'only warn once')
 
   warnings.length = 0

--- a/test/map-like.js
+++ b/test/map-like.js
@@ -5,7 +5,7 @@ if (typeof performance === 'undefined') {
 const t = require('tap')
 const LRU = require('../')
 
-const c = new LRU({ max: 5, maxSize: 5 })
+const c = new LRU({ max: 5, maxSize: 5, sizeCalculation: () => 1 })
 
 t.matchSnapshot(c.keys(), 'empty, keys')
 t.matchSnapshot(c.values(), 'empty, values')

--- a/test/size-calculation.js
+++ b/test/size-calculation.js
@@ -42,14 +42,9 @@ t.test('store strings, size = length', t => {
   t.end()
 })
 
-t.test('bad size calculation fn returns 0', t => {
+t.test('bad size calculation fn throws on set()', t => {
   const c = new LRU({ max: 5, maxSize: 5, sizeCalculation: () => 'asdf' })
-  c.set(1, '1'.repeat(100))
-  t.equal(c.size, 1)
-  t.equal(c.calculatedSize, 0)
-  c.set(2, '2'.repeat(100), { sizeCalculation: () => 'foobar' })
-  t.equal(c.size, 2)
-  t.equal(c.calculatedSize, 0)
+  t.throws(() => c.set(1, '1'.repeat(100)), TypeError)
   t.end()
 })
 

--- a/test/ttl.js
+++ b/test/ttl.js
@@ -67,7 +67,7 @@ const runTests = (LRU, t) => {
   })
 
   t.test('ttl tests with ttlResolution=100', t => {
-    const c = new LRU({ max: 5, ttl: 10, ttlResolution: 100 })
+    const c = new LRU({ ttl: 10, ttlResolution: 100, max: 10 })
     c.set(1, 1)
     t.equal(c.get(1), 1, '1 get not stale', { now: clock._now })
     clock.advance(5)
@@ -99,7 +99,7 @@ const runTests = (LRU, t) => {
   t.test('ttlResolution only respected if non-negative integer', t => {
     const invalids = [ -1, null, undefined, 'banana', {} ]
     for (const i of invalids) {
-      const c = new LRU({ max: 5, ttlResolution: i })
+      const c = new LRU({ ttl: 5, ttlResolution: i, max: 5 })
       t.not(c.ttlResolution, i)
       t.equal(c.ttlResolution, Math.floor(c.ttlResolution))
       t.ok(c.ttlResolution >= 0)
@@ -108,7 +108,7 @@ const runTests = (LRU, t) => {
   })
 
   t.test('ttlAutopurge', t => {
-    const c = new LRU({ max: 2, ttl: 10, ttlAutopurge: true, ttlResolution: 0 })
+    const c = new LRU({ ttl: 10, ttlAutopurge: true, ttlResolution: 0 })
     c.set(1, 1)
     c.set(2, 2)
     t.equal(c.size, 2)


### PR DESCRIPTION
This also prevents setting size=0 if maxSize is set, since that is a
recipe for disaster.

At least one of max, maxSize, or ttl MUST be set, to prevent unbounded
growth of the cache.  And really, without ttlAutopurge, it's effectively
unsafe and unbounded in that case anyway, *especially* if allowStale is
set.  This is potentially "unsafe at any speed" territory, so it emits a
process warning in that case.

If max is not set, then regular Array is used to track items, without
setting an initial Array capacity.  This will often perform much worse,
but in many cases, it's not so bad.  Bigger hazard is definitely
unbounded memory consumption.

Fix: https://github.com/isaacs/node-lru-cache/issues/208