### PR TITLE
Fix the abort controller check

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const perf = typeof performance === 'object' && performance &&
   typeof performance.now === 'function' ? performance : Date
 
-const hasAbortController = typeof AbortController !== undefined
+const hasAbortController = typeof AbortController !== 'undefined'
 
 /* istanbul ignore next - minimal backwards compatibility polyfill */
 const AC = hasAbortController ? AbortController : Object.assign(


### PR DESCRIPTION
- The `typeof AbortController !== undefined` check is incorrect, as typeof gives you strings

- In my case, this broke node-gyp install, which depends (indirectly) on lru-cache