### PR TITLE
fix usage in browser with process polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ const deprecatedProperty = (field, instead) => {
 
 const shouldWarn = code => typeof process === 'object' &&
   process &&
+  process.emitWarning &&
   !warned.has(code)
 
 const warn = (code, what, instead, fn) => {


### PR DESCRIPTION
Some apps use webpack polyfills for the `process` global variable - usually [node-process](https://github.com/defunctzombie/node-process). But this polyfill is pretty otdated and doesn't have `emitWarning` which is used by the lru-cache