### PR TITLE
Update `max` required language in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ npm install lru-cache --save
 ```js
 const LRU = require('lru-cache')
 
-// only 'max' is required, the others are optional, but MAY be
-// required if certain other fields are set.
+// At least one size bound must be provided in order to prevent an unsafe,
+// unbounded cache size.
+// * `max`
+// * `maxSize` (with optional `sizeCalculation`)
+// * `ttl` (with optional `noUpdateTTL`, `ttlResolution`, `ttlAutopurge`,
+//     `allowStale`, `updateAgeOnGet`).
 const options = {
   // the number of most recently used items to keep.
   // note that we may store fewer items than this if maxSize is hit.


### PR DESCRIPTION
Add some clarity about to the README  usage section about cache bounding options and replace incorrect "max is required" statement.

Fixes #224