### PR TITLE
fix: double calculatedSize deduction on delete

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,15 +306,6 @@ class LRUCache {
       }
       this.calculatedSize += this.sizes[index]
     }
-    this.delete = k => {
-      if (this.size !== 0) {
-        const index = this.keyMap.get(k)
-        if (index !== undefined) {
-          this.calculatedSize -= this.sizes[index]
-        }
-      }
-      return LRUCache.prototype.delete.call(this, k)
-    }
   }
   removeItemSize (index) {}
   addItemSize (index, v, k, size) {}

--- a/test/size-calculation.js
+++ b/test/size-calculation.js
@@ -8,6 +8,18 @@ t.test('store strings, size = length', t => {
     maxSize: 100,
     sizeCalculation: n => n.length,
   })
+
+  c.set(5, 'x'.repeat(5))
+  c.set(10, 'x'.repeat(10))
+  c.set(20, 'x'.repeat(20))
+  t.equal(c.calculatedSize, 35)
+  c.delete(20)
+  t.equal(c.calculatedSize, 15)
+  c.delete(5)
+  t.equal(c.calculatedSize, 10)
+  c.clear()
+  t.equal(c.calculatedSize, 0)
+
   const s = 'x'.repeat(10)
   for (let i = 0; i < 5; i++) {
     c.set(i, s)


### PR DESCRIPTION
This fixes a bug with double deduction of `calculatedSize` upon item deletion. 
Most noticeable when both `ttl` and `maxSize` were used together as `.delete` was being called internally on stale items.