### PR TITLE
Fix index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -262,7 +262,7 @@ declare class LRUCache<K, V> implements Iterable<[K, V]> {
   // tslint:disable-next-line:no-unnecessary-generics
   public fetch<ExpectedValue = V>(
     key: K,
-    options?: LRUCache.FetchOptions
+    options?: LRUCache.FetchOptions<K, V>
   ): Promise<ExpectedValue | undefined>
 
   /**
@@ -300,7 +300,7 @@ declare namespace LRUCache {
      *
      * @deprecated since 7.0 use options.sizeCalculation instead
      */
-    length?: SizeCalculator
+    length?: SizeCalculator<K, V>
 
     /**
      * alias for allowStale

--- a/test/load.ts
+++ b/test/load.ts
@@ -6,7 +6,7 @@ for (let i = 0; i < 9; i++) {
   c.set(i, i)
 }
 
-const d = new LRU(c as LRU.Options<number, number>)
+const d = new LRU(c as unknown as LRU.Options<number, number>)
 d.load(c.dump())
 
 t.strictSame(d, c)


### PR DESCRIPTION
This package is unavailable because of some type errors caused by the missing type arguments.

```
lru-cache/index.d.ts(265,15): Error TS2314: Generic type 'FetchOptions<K, V>' requires 2 type argument(s).
lru-cache/index.d.ts(303,14): Error TS2314: Generic type 'SizeCalculator' requires 2 type argument(s).
```