### PR TITLE
Remove DOM lib reference in TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,6 @@
 // Changes by Isaac Z. Schlueter released under the terms found in the
 // LICENSE file within this project.
 
-/// <reference lib="DOM" />
 //tslint:disable:member-access
 declare class LRUCache<K, V> implements Iterable<[K, V]> {
   constructor(options: LRUCache.Options<K, V>)


### PR DESCRIPTION
Hi!

In backend projects, forcing the TypeScript compiler to import the DOM lib can causes issues, in particular shadowing of the Node.js or [Cloudflare global types](https://github.com/cloudflare/workers-types) like `Request`.

This is somewhat of a known issue with TypeScript and packages that include the `
/// <reference lib="DOM" />` snippet break Node.js and other backend-only projects:

* https://stackoverflow.com/questions/63109147/using-typescript-without-dom-types-for-node
* https://github.com/microsoft/TypeScript/issues/43990
* https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/55382

`superagent` is typically a package that used to cause the same issue on server-side projects and it looks like they chose to [remove the DOM lib reference as well](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57641)