### PR TITLE
docs: Fix fetch function signature in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,8 +461,7 @@ can be confusing when setting values specifically to `undefined`,
 as in `cache.set(key, undefined)`.  Use `cache.has()` to
 determine whether a key is present in the cache at all.
 
-### `async fetch(key, { updateAgeOnGet, allowStale, size,
-sizeCalculation, ttl, noDisposeOnSet, forceRefresh } = {}) => Promise`
+### `async fetch(key, { updateAgeOnGet, allowStale, size, sizeCalculation, ttl, noDisposeOnSet, forceRefresh } = {}) => Promise`
 
 If the value is in the cache and not stale, then the returned
 Promise resolves to the value.


### PR DESCRIPTION
Currently the `fetch` method is not displayed correctly when rendering the README.md as Markdown.

<img width="800" alt="Bildschirmfoto 2022-08-15 um 12 06 21" src="https://user-images.githubusercontent.com/7912302/184616943-bbf7b20f-9054-44b2-aecf-9dfdb9e7b116.png">
