### PR TITLE
docs: 'del' does not exist on type (safety-case)

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ const cache = {
     if (cache.timers.has(k)) {
       clearTimeout(cache.timers.get(k))
     }
-    cache.timers.set(k, setTimeout(() => cache.del(k), ttl))
+    cache.timers.set(k, setTimeout(() => cache.delete(k), ttl))
     cache.data.set(k, v)
   },
   get: k => cache.data.get(k),


### PR DESCRIPTION
`cache.del(k)` -> `cache.delete(k)`

Property 'del' does not exist on cache type 