### PR TITLE
Add ESM version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /nyc_output
 /coverage
 /bundle
+/index.mjs

--- a/package.json
+++ b/package.json
@@ -10,17 +10,20 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "",
+    "build": "node ./scripts/transpile-to-esm.mjs",
     "size": "size-limit",
     "test": "tap",
     "snap": "tap",
     "preversion": "npm test",
     "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
+    "prepublishOnly": "npm run build && git push origin --follow-tags",
     "format": "prettier --write .",
     "typedoc": "typedoc ./index.d.ts"
   },
-  "main": "index.js",
+  "type": "commonjs",
+  "main": "./index.js",
+  "module": "./index.mjs",
+  "types": "./index.d.ts",
   "repository": "git://github.com/isaacs/node-lru-cache.git",
   "devDependencies": {
     "@size-limit/preset-small-lib": "^7.0.8",
@@ -41,6 +44,7 @@
   "license": "ISC",
   "files": [
     "index.js",
+    "index.mjs",
     "index.d.ts"
   ],
   "engines": {
@@ -72,5 +76,12 @@
     {
       "path": "./index.js"
     }
-  ]
+  ],
+  "exports": {
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./package.json": "./package.json"
+  }
 }

--- a/scripts/transpile-to-esm.mjs
+++ b/scripts/transpile-to-esm.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+/**
+ * This script manually transpiles CommonJS source into an ESM script for distribution.
+ * Usually we'd use a compiler like Babel or esbuild, but this library uses minimal CommonJS features (only a single default export), and it can be easily and reliably translated to the ESM equivalent via a simple regexp.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises'
+import assert from 'node:assert'
+
+const cjs = await readFile(new URL('../index.js', import.meta.url), 'utf8')
+const esm = cjs.replace(/module.exports\s*=\s*/, 'export default ')
+await writeFile(new URL('../index.mjs', import.meta.url), esm, 'utf8')
+
+/**
+ * As a test, import the generated file to ensure it's a valid ES Module.
+ */
+const { default: LRUCache } = await import('../index.mjs') // dynamic imports use this destructuring syntax to get default exports; this is normal and expected.
+const cache = new LRUCache({ max: 10 })
+cache.set('foo', 'bar')
+assert(cache.get('foo') === 'bar')


### PR DESCRIPTION
This is a minimal implementation to provide a native ESM version of the package.

The main idea is that you don't need to have both files in the repository, and can generate the ESM version just before publishing a new version. I added a minimal build script to do that without adding new dependencies. I tested the result on Node (from both CJS and ESM scripts), and on Vite + webpack (both of which consumed the generated ESM file).

In regards to TypeScript: not changes are necessary because the types are the same for CJS and ESM distribution.

Closes https://github.com/isaacs/node-lru-cache/issues/253