### PR TITLE
fix evict-while-fetch() causing data structure corruption

### DIFF
--- a/index.js
+++ b/index.js
@@ -616,6 +616,7 @@ class LRUCache {
       noUpdateTTL = false
     } else {
       // update
+      this.moveToTail(index)
       const oldVal = this.valList[index]
       if (v !== oldVal) {
         if (this.isBackgroundFetch(oldVal)) {
@@ -632,7 +633,6 @@ class LRUCache {
         this.valList[index] = v
         this.addItemSize(index, size)
       }
-      this.moveToTail(index)
     }
     if (ttl !== 0 && this.ttl === 0 && !this.ttls) {
       this.initializeTTLTracking()


### PR DESCRIPTION
Before this fix, this new test failed with:

```
 FAIL  test/fetch.ts
 ✖ should be equal

  t.equal(c.size, 2)
  t.equal([...c].length, 2)
----^
})

  test: test/fetch.ts placeholder promise is not removed when resolving
  found: 0
  wanted: 2
  compare: ===
  at:
    line: 590
    column: 5
    file: test/fetch.ts
  stack: |
    test/fetch.ts:590:5
    fulfilled (test/fetch.ts:5:58)
```
