### PR TITLE
fix infinite loop when using .get() inside .keys() loop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1393,12 +1393,15 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown> {
    * in order from most recently used to least recently used.
    */
   *keys() {
+    const visited = new Set<K>()
     for (const i of this.#indexes()) {
       const k = this.#keyList[i]
       if (
         k !== undefined &&
+        !visited.has(k) &&
         !this.#isBackgroundFetch(this.#valList[i])
       ) {
+        visited.add(k)
         yield k
       }
     }

--- a/test/for-of-poc.ts
+++ b/test/for-of-poc.ts
@@ -1,0 +1,19 @@
+import t from 'tap'
+import { LRUCache as LRU } from '../'
+
+t.test('for of', t => {
+  const cache = new LRU({ max: 10 })
+  cache.set('a', 1)
+  cache.set('b', 2)
+  cache.set('c', 3)
+  const size = cache.size
+  let count = 0
+  for (const key of cache.keys()) {
+    count++
+    cache.get(key)
+  }
+
+  t.equal(count, size)
+
+  t.end()
+})


### PR DESCRIPTION
This fixes an issue where you can enter an infinite loop if you use `cache.get()` whilst iterating over `cache.keys()`. As far as I understand the infinite loop occurs because the index order changes when you call `cache.get()`. This can be avoided by using `cache.peek()` but is still unexpected. To resolve this, inside the `.keys` method I've captured the value of `#indexes` into an array before iterating over them, to avoid the case where the value changes during iteration.