### PR TITLE
fix: change the order of `exports` field keys to fix type resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,16 +32,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/mjs/index.js",
   "exports": {
-    "./min": {
-      "import": {
-        "types": "./dist/mjs/index.d.ts",
-        "default": "./dist/mjs/index.min.js"
-      },
-      "require": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.min.js"
-      }
-    },
     ".": {
       "import": {
         "types": "./dist/mjs/index.d.ts",
@@ -50,6 +40,16 @@
       "require": {
         "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
+      }
+    },
+    "./min": {
+      "import": {
+        "types": "./dist/mjs/index.d.ts",
+        "default": "./dist/mjs/index.min.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.min.js"
       }
     }
   },


### PR DESCRIPTION
As both `./min` and `.` points to the same type definition file, sometimes TypeScript will resolve the type definition entry to the `./min` key as it appears first.

https://github.com/microsoft/TypeScript/issues/56290#issuecomment-1792883895

While this is not incorrect behavior, it breaks compatibility with older build environments that do not support the `exports` field. (e.g. TypeScript with `moduleResolution: "node"` instead of `bundler` or `node16`), as the `./min` entry is only available through the `exports` field.

Some Vue.js users are experiencing this issue:
https://github.com/vuejs/core/issues/9521