### PR TITLE
chore: updated 'set' method signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ moment.
 
 The total size of items in cache when using size tracking.
 
-### `set(key, value, [{ size, sizeCalculation, ttl, noDisposeOnSet, start, status }])`
+### `set(key, value, { size, sizeCalculation, ttl, noDisposeOnSet, start, status } = {})`
 
 Add a value to the cache.
 


### PR DESCRIPTION
Fixed one small typo in the docs, in the current version it looks like 'options' is an array, but it's not.