### PR TITLE
Add an internal function to refresh timer used for ttl

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
 
 // module-private names and types
 type Perf = { now: () => number }
-const perf: Perf =
+let perf: Perf =
   typeof performance === 'object' &&
   performance &&
   typeof performance.now === 'function'
@@ -1261,6 +1261,7 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown>
         c.#rindexes(options),
       isStale: (index: number | undefined) =>
         c.#isStale(index as Index),
+      refreshTTLTimerReference: () => c.#refreshTTLTimerReference(),
     }
   }
 
@@ -1557,6 +1558,15 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown>
       const t = ttls[index]
       return !!t && !!s && (cachedNow || getNow()) - s > t
     }
+  }
+
+  #refreshTTLTimerReference() {
+    perf =
+      typeof performance === 'object' &&
+      performance &&
+      typeof performance.now === 'function'
+        ? performance
+        : Date
   }
 
   // conditionally set private methods related to TTL

--- a/test/ttl-timer-refresh.ts
+++ b/test/ttl-timer-refresh.ts
@@ -1,0 +1,35 @@
+if (typeof performance === 'undefined') {
+  global.performance = require('perf_hooks').performance
+}
+import t from 'tap'
+import { LRUCache } from '../dist/esm/index.js'
+import { expose } from './fixtures/expose.js'
+
+t.test('ttl timer refresh', async t => {
+  // @ts-ignore
+  global.performance = {
+    now: () => 5,
+  }
+  const { LRUCache: LRU } = t.mockRequire('../', {})
+  const c = new LRU({ max: 5, ttl: 10, ttlResolution: 0 })
+  const e = expose(c, LRU)
+
+  c.set('a', 1)
+
+  const status: LRUCache.Status<any> = {}
+  c.get('a', { status })
+  t.equal(status.now, 5)
+
+  // New timer mock
+  // @ts-ignore
+  global.performance = {
+    now: () => 10,
+  }
+
+  c.get('a', { status })
+  t.equal(status.now, 5, 'still using the old ttl timer')
+
+  e.refreshTTLTimerReference()
+  c.get('a', { status })
+  t.equal(status.now, 10, 'using the new ttl timer')
+})


### PR DESCRIPTION
When overriding the global timers with a custom timer, the timer used for ttl is not updated and will continue to use the timer that was defined when the package was first imported.

This adds an internal function that can be called to refresh the timer used for ttl with the current global timer.

Fixes https://github.com/isaacs/node-lru-cache/issues/349