### PR TITLE
docs: fix unresolved @link comments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -533,7 +533,7 @@ export namespace LRUCache {
    *
    * This is the union of {@link GetOptions} and {@link SetOptions}, plus
    * {@link MemoOptions.forceRefresh}, and
-   * {@link MemoerOptions.context}
+   * {@link MemoOptions.context}
    *
    * Any of these may be modified in the {@link OptionsBase.memoMethod}
    * function, but the {@link GetOptions} fields will of course have no
@@ -1928,7 +1928,7 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown> {
 
   /**
    * Return an array of [key, {@link LRUCache.Entry}] tuples which can be
-   * passed to {@link LRLUCache#load}.
+   * passed to {@link LRUCache#load}.
    *
    * The `start` fields are calculated relative to a portable `Date.now()`
    * timestamp, even if `performance.now()` is available.
@@ -2628,7 +2628,7 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown> {
    * `cache.fetch(k)` into just an async wrapper around `cache.get(k)`) or
    * because `ignoreFetchAbort` was specified (either to the constructor or
    * in the {@link LRUCache.FetchOptions}). Also, the
-   * {@link OptionsBase.fetchMethod} may return `undefined` or `void`, making
+   * {@link LRUCache.OptionsBase.fetchMethod} may return `undefined` or `void`, making
    * the test even more complicated.
    *
    * Because inferring the cases where `undefined` might be returned are so


### PR DESCRIPTION

**before**
```sh
❯ npx typedoc --tsconfig ./.tshy/esm.json "./src/*.ts" --validation.invalidLink --treatValidationWarningsAsErrors; echo $?
[warning] The signature ZeroArray.reduce has an @param with name "initialValue", which was not used
[warning] The signature ZeroArray.reduceRight has an @param with name "initialValue", which was not used
[warning] Failed to resolve link to "LRLUCache#load" in comment for LRUCache.dump
[warning] Failed to resolve link to "OptionsBase.fetchMethod" in comment for LRUCache.forceFetch
[warning] Failed to resolve link to "MemoerOptions.context" in comment for LRUCache.MemoizerMemoOptions
[warning] Found 0 errors and 5 warnings
4
```

**after**
```
❯ git co patch-1
Switched to branch 'patch-1'
Your branch is up to date with 'origin/patch-1'.
❯ npx typedoc --tsconfig ./.tshy/esm.json "./src/*.ts" --validation.invalidLink --treatValidationWarningsAsErrors; echo $?
[warning] The signature ZeroArray.reduce has an @param with name "initialValue", which was not used
[warning] The signature ZeroArray.reduceRight has an @param with name "initialValue", which was not used
[info] Documentation generated at ./docs
[warning] Found 0 errors and 2 warnings
0
```