### PR TITLE
Wrap perf.now calls to avoid stale mock impls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,12 @@
  */
 
 // module-private names and types
-type Perf = { now: () => number }
-const perf: Perf =
+const getPerfNow: () => number =
   typeof performance === 'object' &&
   performance &&
   typeof performance.now === 'function'
-    ? performance
-    : Date
+    ? () => performance.now()
+    : () => Date.now()
 
 const warned = new Set<string>()
 
@@ -1479,7 +1478,7 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown> {
     this.#ttls = ttls
     this.#starts = starts
 
-    this.#setItemTTL = (index, ttl, start = perf.now()) => {
+    this.#setItemTTL = (index, ttl, start = getPerfNow()) => {
       starts[index] = ttl !== 0 ? start : 0
       ttls[index] = ttl
       if (ttl !== 0 && this.ttlAutopurge) {
@@ -1498,7 +1497,7 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown> {
     }
 
     this.#updateItemAge = index => {
-      starts[index] = ttls[index] !== 0 ? perf.now() : 0
+      starts[index] = ttls[index] !== 0 ? getPerfNow() : 0
     }
 
     this.#statusTTL = (status, index) => {
@@ -1519,7 +1518,7 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown> {
     // that costly call repeatedly.
     let cachedNow = 0
     const getNow = () => {
-      const n = perf.now()
+      const n = getPerfNow()
       if (this.ttlResolution > 0) {
         cachedNow = n
         const t = setTimeout(
@@ -1915,7 +1914,7 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown> {
       const ttl = this.#ttls[i]
       const start = this.#starts[i]
       if (ttl && start) {
-        const remain = ttl - (perf.now() - start)
+        const remain = ttl - (getPerfNow() - start)
         entry.ttl = remain
         entry.start = Date.now()
       }
@@ -1953,7 +1952,7 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown> {
         entry.ttl = this.#ttls[i]
         // always dump the start relative to a portable timestamp
         // it's ok for this to be a bit slow, it's a rare operation.
-        const age = perf.now() - (this.#starts[i] as number)
+        const age = getPerfNow() - (this.#starts[i] as number)
         entry.start = Math.floor(Date.now() - age)
       }
       if (this.#sizes) {
@@ -1984,7 +1983,7 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown> {
         //
         // it's ok for this to be a bit slow, it's a rare operation.
         const age = Date.now() - entry.start
-        entry.start = perf.now() - age
+        entry.start = getPerfNow() - age
       }
       this.set(key, entry.value, entry)
     }


### PR DESCRIPTION
I'm running in to the same issue as described by https://github.com/isaacs/node-lru-cache/pull/351.

However I think a simpler solution is to wrap the calls to get now, avoiding any need for developer intervention to update the implementation.

Alternatively you could wrap the whole statement in a getter and check if performance is available for every call too. That isn't an issue though in the situation with using sinon timers though.