### PR TITLE
fix: reschedule autopurge timer when updateAgeOnGet resets TTL start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1569,6 +1569,22 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown> {
 
     this.#updateItemAge = index => {
       starts[index] = ttls[index] !== 0 ? this.#perf.now() : 0
+      // reschedule autopurge timer so it doesn't find the entry non-stale and go silent
+      if (purgeTimers?.[index]) {
+        clearTimeout(purgeTimers[index])
+        const ttl = ttls[index] as number
+        const t = setTimeout(() => {
+          if (this.#isStale(index)) {
+            this.#delete(this.#keyList[index] as K, 'expire')
+          }
+        }, ttl + 1)
+        /* c8 ignore start */
+        if (t.unref) {
+          t.unref()
+        }
+        /* c8 ignore stop */
+        purgeTimers[index] = t
+      }
     }
 
     this.#statusTTL = (status, index) => {

--- a/test/ttl.ts
+++ b/test/ttl.ts
@@ -480,6 +480,60 @@ const runTests = (LRU: typeof LRUCache, t: Test) => {
     t.end()
   })
 
+  t.test('updateAgeOnGet reschedules ttlAutopurge timer', t => {
+    const c = new LRU({
+      ttl: 100,
+      ttlAutopurge: true,
+      updateAgeOnGet: true,
+      ttlResolution: 0,
+    })
+    // set an entry
+    c.set('a', 1)
+    t.equal(c.size, 1)
+
+    // get it before original TTL expires — this should refresh the TTL
+    clock.advance(80)
+    t.equal(c.get('a'), 1, 'still alive before original TTL')
+    t.equal(c.size, 1, 'size is 1 after get')
+
+    // advance past the original TTL (80 + 30 = 110 from set, but only 30 from get)
+    clock.advance(30)
+    t.equal(c.size, 1, 'entry survives past original TTL because get refreshed it')
+    t.equal(c.get('a'), 1, 'entry is still retrievable')
+
+    // now let the refreshed TTL expire without any more gets
+    // after the second get above, the TTL was refreshed again
+    // advance past that refreshed TTL (100 + 1 for the timer margin)
+    clock.advance(102)
+    t.equal(c.size, 0, 'entry is autopurged after refreshed TTL expires')
+    t.equal(c.get('a'), undefined, 'entry is gone')
+
+    t.end()
+  })
+
+  t.test('updateAgeOnGet + ttlAutopurge: entry eventually purged if not re-accessed', t => {
+    const c = new LRU({
+      ttl: 50,
+      ttlAutopurge: true,
+      updateAgeOnGet: true,
+      ttlResolution: 0,
+    })
+    c.set('b', 2)
+    t.equal(c.size, 1)
+
+    // access once before TTL expires, refreshing the timer
+    clock.advance(30)
+    t.equal(c.get('b'), 2, 'alive before TTL')
+
+    // do NOT access again — let the refreshed TTL expire
+    // the refreshed TTL starts at t=30, expires at t=30+50+1=81
+    clock.advance(52)
+    t.equal(c.size, 0, 'entry autopurged after refreshed TTL with no further access')
+    t.equal(c.get('b'), undefined, 'entry is gone')
+
+    t.end()
+  })
+
   t.end()
 }
 


### PR DESCRIPTION
I am not sure if this is the correct way to report this, but this is what I've found. Feel free to close this if this is inappropriate.

## Bug

When using `updateAgeOnGet: true` with `ttlAutopurge: true`, entries that are `.get()`'d at least once become permanently stuck in the cache. The autopurge timer fires but finds the entry "not stale" (because `updateAgeOnGet` reset the start time), and no replacement timer is ever scheduled.

## Reproduction

```js
import { LRUCache } from 'lru-cache';

const cache = new LRUCache({
  max: 100,
  ttl: 2000,
  ttlAutopurge: true,
  updateAgeOnGet: true,
});

cache.set('A', { name: 'A' });
cache.set('B', { name: 'B' });

// One .get() is enough to make an entry immortal
setTimeout(() => cache.get('A'), 500);

// B (never .get()'d) correctly expires at ~2s
// A stays forever - .has('A') returns false but size never drops
setTimeout(() => {
  console.log(`size=${cache.size}, has(A)=${cache.has('A')}`);
  // size=1, has(A)=false - entry is stale but never purged
}, 15000);
```

Output:
```
size=1, has(A)=false
```

## Root cause

`#setItemTTL` (called on `.set()`) is the only place that schedules an autopurge timer. `#updateItemAge` (called on `.get()` when `updateAgeOnGet: true`) only resets the start time without rescheduling the timer:

```ts
this.#updateItemAge = index => {
  starts[index] = ttls[index] !== 0 ? this.#perf.now() : 0
  // no timer rescheduled
}
```

The sequence:
1. `.set('A')` at t=0 - schedules `setTimeout(fn, 2001)`
2. `.get('A')` at t=500ms - `starts[0] = now()`, no timer change
3. Timer fires at t=2001ms - `now() - starts[0]` = ~1500ms < 2000ms, not stale, does nothing
4. No timer ever runs again, entry is immortal

## Fix

Reschedule the autopurge timer in `#updateItemAge` when one exists, following the same pattern as `#setItemTTL`. The fix only activates when all three conditions are true:
- `ttlAutopurge: true` (autopurge timers exist)
- `updateAgeOnGet: true` or `updateAgeOnHas: true` (age is being updated)
- The entry was previously `.set()` with a TTL (timer exists for that index)

All 17,670 existing tests pass with this change. Two new test cases are included.

## Impact

We discovered this in production where ~160 connection pool objects were permanently stuck in an LRU cache despite a 10-minute TTL, causing ~1.5Gi of unreclaimable native memory per Node.js process.

## Workaround

Use `.set(key, existingValue)` instead of relying on `updateAgeOnGet`, which properly calls `#setItemTTL` and reschedules the timer. Set `noDisposeOnSet: true` to prevent the dispose callback from firing on re-set.

## Version

lru-cache 11.2.4 (also verified on 11.2.6)
