### PR TITLE
fix: update repository metadata to https

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/isaacs/node-lru-cache.git"
+    "url": "git+https://github.com/isaacs/node-lru-cache.git"
   },
   "devDependencies": {
     "benchmark": "^2.1.4",


### PR DESCRIPTION
The `repository` field in `package.json` currently uses an unauthenticated or SSH git URL. This requires package consumers and registry tools to have authenticated SSH GitHub access or unblocked git protocols to resolve the repository metadata.

This PR updates it to an HTTPS URL (`git+https://github.com/...`) which is publicly accessible.