### PR TITLE
fix: stop iteration from revisiting entries moved by get()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1814,9 +1814,16 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown> {
 
   *#indexes({ allowStale = this.allowStale } = {}) {
     if (this.#size) {
+      // A fn called during iteration (eg get()) can move entries within the
+      // list, which would send this walk in circles. Track what has been
+      // yielded so each index is visited at most once.
+      const yielded = new Set<Index>()
       for (let i = this.#tail; this.#isValidIndex(i); ) {
-        if (allowStale || !this.#isStale(i)) {
-          yield i
+        if (!yielded.has(i)) {
+          yielded.add(i)
+          if (allowStale || !this.#isStale(i)) {
+            yield i
+          }
         }
         if (i === this.#head) {
           break
@@ -1829,9 +1836,13 @@ export class LRUCache<K extends {}, V extends {}, FC = unknown> {
 
   *#rindexes({ allowStale = this.allowStale } = {}) {
     if (this.#size) {
+      const yielded = new Set<Index>()
       for (let i = this.#head; this.#isValidIndex(i); ) {
-        if (allowStale || !this.#isStale(i)) {
-          yield i
+        if (!yielded.has(i)) {
+          yielded.add(i)
+          if (allowStale || !this.#isStale(i)) {
+            yield i
+          }
         }
         if (i === this.#tail) {
           break

--- a/test/get-during-iteration.ts
+++ b/test/get-during-iteration.ts
@@ -1,0 +1,23 @@
+import t from 'tap'
+import { LRUCache } from '../src/index.js'
+
+// get() during forEach/keys() moves the entry to MRU. The walker follows
+// the re-linked list and revisits entries forever (c,b,c,b...), eventually
+// crashing with RangeError: Invalid array length.
+//
+// Expected: each key visited exactly once, matching Map iteration semantics.
+
+const c = new LRUCache<number, number>({ max: 5 })
+for (let i = 0; i < 5; i++) c.set(i, i)
+
+const visited: number[] = []
+t.doesNotThrow(() => {
+	for (const k of c.keys()) {
+		visited.push(k)
+		c.get(k)
+		if (visited.length > 10) throw new Error('infinite loop')
+	}
+}, 'iteration terminates')
+
+t.same(visited.sort((a, b) => a - b), [0, 1, 2, 3, 4])
+t.end()


### PR DESCRIPTION
Iterating with `forEach`/`keys()`/`entries()`/`values()` while calling `get()` on the visited entry moves it to the MRU end via `#moveToTail`. The index walkers follow the re-linked `prev`/`next` pointers and land back on nodes they already yielded, so the loop revisits the same entries forever until something throws:

```js
const c = new LRUCache({ max: 3 })
c.set('a', 1); c.set('b', 2); c.set('c', 3)

for (const k of c.keys()) {
  c.get(k)
}
// visits c,b,c,b,c,b,... forever
// eventually: RangeError: Invalid array length
```

Walk-through of the two-entry cycle (`#indexes`, walking tail → head via `#prev`):

1. visit `c` (tail), callback `get('c')` — no-op, already tail. Next: `prev[c] = b`.
2. visit `b`, callback `get('b')` — `moveToTail(b)` unlinks b from between a and c, relinks `a↔c`, appends b after c (`tail = b`). List is now `a ↔ c ↔ b`.
3. walker does `i = prev[b] = c` → visits `c` again, whose `get` restores the old order… and the walk oscillates between steps 2–3 indefinitely.

Deletes during iteration were already handled by the `#isValidIndex` check (the entry's index no longer maps back to its key); this covers the move case.

## Fix

Track yielded indexes in `#indexes` / `#rindexes` and skip them if the walk circles back. Each entry is now visited at most once per iteration, matching Map iteration semantics.

The Set is allocated once per iteration call; for the common case where nothing mutates mid-walk, behavior and results are unchanged.

## Tests

`test/get-during-iteration.ts` asserts that iterating while calling `get(k)` terminates and visits each key exactly once — fails on master (infinite loop), passes with this change.

Full suite: `18430 total / 18364 pass / 66 fail` on this branch vs `18326 / 18258 / 68` on unmodified master. The only failing file in both runs is the pre-existing flaky `test/tracing.ts`; the remaining delta is subtests of my new test file plus run-to-run noise in the same tracing/fetch tests.
